### PR TITLE
Remove references to fisica in build.xml.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -159,9 +159,6 @@
         <pathelement location="${jython}"/>
         <pathelement location="${corejar}"/>
         <pathelement location="${pdejar}"/>
-        <fileset dir="libraries/fisica">
-          <include name="*.jar"/>
-        </fileset>
       </classpath>
     </javac>
     <copy todir="bin">


### PR DESCRIPTION
I was rebuilding my copy of processing.py and the build failed because it couldn't find fisica any more. So, I removed the last reference to fisica in build.xml.
