### PR TITLE
More regexs for pde2py: closes #42

### DIFF
--- a/buildtime/py/pde2py.py
+++ b/buildtime/py/pde2py.py
@@ -62,28 +62,93 @@ def copy_file(s, d, xform=None):
 
 def xform_py(d, text):
     d = re.sub(r'^(.+?).pde$', r'\1.py', d)
+    # Remove closing brace.
+    text = text.replace('}', '')
+    # Remove trailing spaces - first pass.
+    text = re.sub(r'(?m)[ ]{1,}$', '', text)
+    # Fix inline comments.
     text = text.replace('//', '#')
-    text = text.replace('  ', '    ')
-    text = re.sub(r'(?m)^(\s*)(?:void|int|float|String)\s+([a-zA-Z0-9]+)\s*\(([^\)]*)\)',
-                  r'\1def \2(\3):',
-                  text)
+    # Save "history" for indent. We may end up with extraneous double-spaces
+    # after this; we have no way of distinguishing between them and
+    # legitimate indent.
+    text = re.sub(r' {2}', r'\t', text)
+    # Fix functions - remove return type identifiers and add 'def' keyword.
+    text = re.sub(
+        r'(?m)^(\s*)(?:public void|void|public int|int|public float|float|public String|String)\s+([a-zA-Z0-9]+)\s*\(([^\)]*)\)',
+        r'\1def \2(\3):',
+        text)
+    # Fix class definitions.
     text = re.sub(
         r'(?m)^\s*(?:abstract\s+)?class\s+(\S+)\s*$', r'class \1:', text)
     text = re.sub(
-        r'(?m)^\s*(?:abstract\s+)?class\s+(\S+)\s*extends\s*(\S+)\s*$', r'class \1(\2):', text)
-    text = re.sub(r'(?m)^(\s*)(?:void|int|float|String)\s+', r'\1', text)
-    text = re.sub(r'[{};]', '', text)
-    text = re.sub(r'\n\n+', '\n', text)
-    text = re.sub(r'(?m)^(\s*)if\s*\((.+?)\)\s*$', r'\1if \2:', text)
-    text = re.sub(r'(?m)^(\s*)else\s+if\s*\((.+?)\)\s*$', r'\1elif \2:', text)
-    text = re.sub(r'(?m)^(\s*)else\s*$', r'\1else:', text)
+        r'(?m)^\s*(?:abstract\s+)?class\s+(\S+)\s*extends\s*(\S+)\s*$',
+        r'class \1(\2):',
+        text)
+    text = re.sub(r'(?m)^(\s*)(?:void|int|float|String|public)\s+', r'\1', text)
+    # Remove as many type identifiers as possible.
+    text = re.sub(
+        r'\b(int|byte|short|long|float|double|boolean|char|String|final)(\(|\s|\[)+?',
+        r'',
+        text)
+    text = re.sub(
+        r'\((int|byte|short|long|float|double|boolean|char|String|final|Integer|Object)\)',
+        r'',
+        text)
+    # Fix 'if'.
+    text = re.sub(r'(?m)^(\s*)if\s*(?:\()?(.+\)*?)(?:\))(.*)(?:\{)*$', r'\1if \2:\n\1\t\3', text)
+    # Fix 'else if'.
+    text = re.sub(r'(?m)^(\s*)else\s+if\s*(?:\()?(.+\)*?)(?:\))(.*)(?:\{)*$', r'\1elif \2:', text)
+    # Fix 'else'.
+    text = re.sub(r'(?m)^(\s*)else(.*)(?:\{)*$', r'\1else:\n\1\t\2', text)
+    # Fix block comments (convert to docstrings, really).
     text = re.sub(r'/\*+|\*+/', '"""', text)
+    # Remove 'new'.
     text = text.replace('new ', '')
+    # Fix booleans.
     text = text.replace('true', 'True')
     text = text.replace('false', 'False')
-    text = text.replace('this.', 'self.')
-    text = text.replace('||', 'or')
-    text = text.replace('&&', 'and')
+    # Fix 'this'.
+    text = text.replace('this(\.?)', 'self\1')
+    # Fix boolean operators.
+    text = text.replace('||', ' or ')
+    text = text.replace('&&', ' and ')
+    # Remove 'f' (float coercion... I guess...
+    #             How is '0.09f' different from '0.09'?! ::smh::).
+    text = re.sub(r'(\d)f', r'\1', text)
+    # Add spaces after commas.
+    text = text.replace(',', ', ')
+    # Remove spaces before colons.
+    text = text.replace(' :', ':')
+    # Add spaces around operators.
+    text = re.sub(
+        r'([a-zA-Z0-9_()]+?)(!=|\*=|\+=|-=|\/=|==|>=|<=|=|\*|\+|-|\/|>|<|%|&)([a-zA-Z0-9_()]+?)',
+        r'\1 \2 \3',
+        text)
+    # Remove spaces around parens/brackets.
+    text = re.sub(r'(?: {1,})(\)|\])', r'\1', text)
+    text = re.sub(r'(\(|\[)(?: {1,})', r'\1', text)
+    # Fix up 'for'. Hopefully this makes it a *bit* more readable. In any
+    #       case, we'll try to at least get the colon in at the end.
+    text = re.sub(
+        r'(?m)^(\s*)for\s*(?:\()(?:int|float)*(.*?);(.*?);(.*?)(?:\)).*$',
+        r'\1for \2 in range(\3):  # \4',
+        text)
+    # Fix up imports. Obviously, since we're going from 'import *' to
+    #       specifics, the end user has to figure out what to import. That
+    #       being the case, I'm commenting out the imports to (hopefully)
+    #       call attention to them. In any case, they'll definitely be found
+    #       by any good linter
+    text = re.sub(r'(?m)^import(.*)\.\*;', r'# from\1 import', text)
+    # Remove brackets/remaining braces/semicolons.
+    text = re.sub(r'[{;]', '', text)
+    # Remove multiple spaces.
+    text = re.sub(r'( ){2,}', ' ', text)
+    # Remove trailing spaces, second pass.
+    text = re.sub(r'(?m)[ ]{1,}$', '', text)
+    # Restore indent with 4 spaces.
+    text = re.sub(r'\t', '    ', text)
+    # Remove multiple blank lines.
+    text = re.sub(r'^\n\n\n', '\n', text)
     return (d, text)
 
 


### PR DESCRIPTION
Now with 100% more comments :D
Try hard to maintain proper indentation in the midst of all of this, for
obvious reasons.
Fix up Java 'for' constructs (cue 'Ode To Joy': this actually works
pretty well).
Touched up 'if'/'else if'/'else'.
Fix but comment imports (i.e., from 'import java.util.*' to '# from
java.util import')
Remove more type identifiers.
Add 'public void' to set of strings to remove from 'defs' etc.
Fix issue with this->self not working properly in some places.
Remove truly annoying 'float'... specifiers? I don't even know what this
is: '0.09f'
Remove 4+ consecutive blank lines (I'm super-annoyed that fixing 'for's
and 'if's seems to have worsened the multiple-blank-line issue).
Remove spaces:
Trailing/only characters on line.
Around operators (this definitely needs work)
After commas.
Before colons.
Around parens.

TODO: Inline comments. To wit: 2 spaces before '#', one after. I have
too much of a migraine to go on :P
