### PR TITLE
Make LibraryImporter a little more robust

### DIFF
--- a/runtime/src/jycessing/LibraryImporter.java
+++ b/runtime/src/jycessing/LibraryImporter.java
@@ -235,19 +235,13 @@ class LibraryImporter {
             Joiner.on(".").join(Arrays.asList(path).subList(0, path.length - 1));
 
         if (!validPythonIdentifier.matcher(className).matches()) {
-          System.err.println("Couldn't import " + packageName + "." + className
-              + " because it isn't a valid python identifier; hopefully it's not important");
+          log("Rejecting " + name);
           continue;
         }
 
         final String importStatement = String.format("from %s import %s", packageName, className);
-        try {
-          interp.exec(importStatement);
-          log(importStatement);
-        } catch (Exception e) {
-          System.err.println("Couldn't import " + packageName + "." + className
-              + " for some reason. Maybe it depends on another library?");
-        }
+        log(importStatement);
+        interp.exec(importStatement);
       }
     }
   }


### PR DESCRIPTION
...alternative title, "Let me import UnfoldingMaps because I want to use it in a demonstration tomorrow."
Partially addresses [#85](https://github.com/jdf/Processing.py-Bugs/issues/85) and [#86](https://github.com/jdf/Processing.py-Bugs/issues/86), by allowing LibraryImporter to skip over things it knows will be problematic, and to recover when imports don't work. It's probably a little too permissive, but I want to err on the side of libraries _mostly_ working for now.
