### PR TITLE
Only import the parts of libraries we need.

### DIFF
--- a/runtime/src/jycessing/LibraryImporter.java
+++ b/runtime/src/jycessing/LibraryImporter.java
@@ -22,6 +22,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -182,7 +183,7 @@ class LibraryImporter {
       log("No export.txt in " + contentsDir.getAbsolutePath());
       return null;
     }
-    final HashMap<String, String[]> exportTable;
+    final Map<String, String[]> exportTable;
     try {
       exportTable = parseExportTxt(exportTxt);
     } catch (Exception e) {
@@ -264,13 +265,15 @@ class LibraryImporter {
    * 
    * @param exportTxt The export.txt file; must exist.
    */
-  private HashMap<String, String[]> parseExportTxt(final File exportTxt) throws Exception {
+  private Map<String, String[]> parseExportTxt(final File exportTxt) throws Exception {
     log("Parsing " + exportTxt.getAbsolutePath());
     
     final Properties exportProps = new Properties();
-    exportProps.load(new FileReader(exportTxt));
+    try (final FileReader in = new FileReader(exportTxt)) {
+      exportProps.load(in);
+    }
     
-    final HashMap<String, String[]> exportTable = new HashMap<>();
+    final Map<String, String[]> exportTable = new HashMap<>();
     
     for (final String platform : exportProps.stringPropertyNames()) {
       final String exportCSV = exportProps.getProperty(platform);


### PR DESCRIPTION
According to the [edicts of Processing](https://github.com/processing/processing/wiki/Library-Basics).

Fixes [#87](https://github.com/jdf/Processing.py-Bugs/issues/87).

(Also, while working on this I noticed that we recreate LibraryImporter every time we run a sketch. This means that we re-add stuff to the various paths - it doesn't duplicate anything, but it does take a second or two with a slow hard drive. Should I change that?)
