### PR TITLE
Updated Minim example to use add_library()

### DIFF
--- a/examples.py/Library/Minim (Sound)/LoadSample.py
+++ b/examples.py/Library/Minim (Sound)/LoadSample.py
@@ -34,7 +34,7 @@
  * Press 'k' to trigger the sample.
 """
 
-from ddf.minim import Minim
+add_library('minim')
 
 def setup():
     size(512, 200)


### PR DESCRIPTION
The example for Minim is out of date.

Aside, I also noticed this example isn't included in the `Examples...` folder when Python mode is installed. Is that normal?

I'm playing around with audio so I may have more self contained examples later. In particular, I might look at translating Minim examples into Python.