### PR TITLE
Allowing running via a symbolic link

### DIFF
--- a/processing-py.sh
+++ b/processing-py.sh
@@ -19,7 +19,8 @@ JVM_ARGS="-Xmx1024m"
 #
 ####
 JAVA=`which java`
-BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+THIS_FILE="$( readlink "$( which ${BASH_SOURCE[0]} )" || echo ${BASH_SOURCE[0]} )"
+BASEDIR="$( cd "$( dirname $THIS_FILE )" && pwd )"
 PLATFORM='unknown'
 SPLASH="-splash:$BASEDIR/libraries/runtime/splash.png"
 REDIRECT="--noredirect"


### PR DESCRIPTION
Check if the script is being accessed via a symbolic link, and if so correctly detect the actual location of the script so that Processing-py jar file and libraries will be accessible.

I install the package under /opt on an OS X machine. The extra symlink-resolution step is required for using a symlink from /usr/local/bin to the actual script's location.
