### PR TITLE
Fix `Create Shapes` examples for deprecated `autoglobal`.

### DIFF
--- a/mode/examples/Topics/Create Shapes/BeginEndContour/BeginEndContour.pyde
+++ b/mode/examples/Topics/Create Shapes/BeginEndContour/BeginEndContour.pyde
@@ -4,32 +4,31 @@ BeginEndContour
 This example shows how to cut a shape out of another using beginContour() and endContour().
 """
 
-shape = None
 
 def setup():
-    global shape
+    global shp
     size(640, 360, P2D)
     smooth()
     # Make a shape
-    shape = createShape()
-    shape.beginShape()
-    shape.fill(0)
-    shape.stroke(255)
-    shape.strokeWeight(2)
+    shp = createShape()
+    shp.beginShape()
+    shp.fill(0)
+    shp.stroke(255)
+    shp.strokeWeight(2)
     # Exterior part of shape
-    shape.vertex(-100, -100)
-    shape.vertex(100, -100)
-    shape.vertex(100, 100)
-    shape.vertex(-100, 100)
+    shp.vertex(-100, -100)
+    shp.vertex(100, -100)
+    shp.vertex(100, 100)
+    shp.vertex(-100, 100)
     # Interior part of shape
-    shape.beginContour()
-    shape.vertex(-10, -10)
-    shape.vertex(10, -10)
-    shape.vertex(10, 10)
-    shape.vertex(-10, 10)
-    shape.endContour()
+    shp.beginContour()
+    shp.vertex(-10, -10)
+    shp.vertex(10, -10)
+    shp.vertex(10, 10)
+    shp.vertex(-10, 10)
+    shp.endContour()
     # Finishing off shape
-    shape.endShape(CLOSE)
+    shp.endShape(CLOSE)
 
 
 def draw():
@@ -37,6 +36,5 @@ def draw():
     # Display shape
     translate(width / 2, height / 2)
     # Shapes can be rotated
-    shape.rotate(0.01)
-    shape(shape)
-
+    shp.rotate(0.01)
+    shape(shp)

--- a/mode/examples/Topics/Create Shapes/BeginEndContour/BeginEndContour.pyde
+++ b/mode/examples/Topics/Create Shapes/BeginEndContour/BeginEndContour.pyde
@@ -4,31 +4,32 @@ BeginEndContour
 This example shows how to cut a shape out of another using beginContour() and endContour().
 """
 
-s = None
+shape = None
 
 def setup():
+    global shape
     size(640, 360, P2D)
     smooth()
     # Make a shape
-    s = createShape()
-    s.beginShape()
-    s.fill(0)
-    s.stroke(255)
-    s.strokeWeight(2)
+    shape = createShape()
+    shape.beginShape()
+    shape.fill(0)
+    shape.stroke(255)
+    shape.strokeWeight(2)
     # Exterior part of shape
-    s.vertex(-100, -100)
-    s.vertex(100, -100)
-    s.vertex(100, 100)
-    s.vertex(-100, 100)
+    shape.vertex(-100, -100)
+    shape.vertex(100, -100)
+    shape.vertex(100, 100)
+    shape.vertex(-100, 100)
     # Interior part of shape
-    s.beginContour()
-    s.vertex(-10, -10)
-    s.vertex(10, -10)
-    s.vertex(10, 10)
-    s.vertex(-10, 10)
-    s.endContour()
+    shape.beginContour()
+    shape.vertex(-10, -10)
+    shape.vertex(10, -10)
+    shape.vertex(10, 10)
+    shape.vertex(-10, 10)
+    shape.endContour()
     # Finishing off shape
-    s.endShape(CLOSE)
+    shape.endShape(CLOSE)
 
 
 def draw():
@@ -36,6 +37,6 @@ def draw():
     # Display shape
     translate(width / 2, height / 2)
     # Shapes can be rotated
-    s.rotate(0.01)
-    shape(s)
+    shape.rotate(0.01)
+    shape(shape)
 

--- a/mode/examples/Topics/Create Shapes/GroupPShape/GroupPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/GroupPShape/GroupPShape.pyde
@@ -4,15 +4,12 @@ GroupPShape
 This example shows how to group multiple PShapes into one PShape.
 """
 
-# A PShape that will group PShapes
-group = None
-
 
 def setup():
     global group
     size(640, 360, P2D)
     smooth()
-    # Create the shape as a group.
+    # A PShape that will group PShapes
     group = createShape(GROUP)
     # Make a polygon PShape.
     star = createShape()

--- a/mode/examples/Topics/Create Shapes/GroupPShape/GroupPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/GroupPShape/GroupPShape.pyde
@@ -9,6 +9,7 @@ group = None
 
 
 def setup():
+    global group
     size(640, 360, P2D)
     smooth()
     # Create the shape as a group.

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/ParticleSystemPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/ParticleSystemPShape.pyde
@@ -10,6 +10,7 @@ from particle_system import ParticleSystem
 ps = None
 
 def setup():
+    global ps
     size(640, 360, P2D)
     # A particle system with 10,000 particles.
     ps = ParticleSystem(10000)
@@ -32,4 +33,3 @@ def draw():
     fill(255)
     textSize(16)
     text("Frame rate: " + str(int(frameRate)), 10, 20)
-

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/ParticleSystemPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/ParticleSystemPShape.pyde
@@ -6,8 +6,6 @@ A particle system optimized for drawing using PShape.
 
 from particle_system import ParticleSystem
 
-# Particle System object
-ps = None
 
 def setup():
     global ps

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle.py
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle.py
@@ -1,64 +1,67 @@
-import globals
-
 # An individual Particle
 
 
 class Particle(object):
+    # A single force
+    Gravity = PVector(0, 0.1)
 
     def __init__(self, sprite):
-        # A single force
-        self.gravity = PVector(0, 0.1)
+        # `lifespan`, `velocity`, and `center` are only **declared** here.
+        self.lifespan = 0
+        self.velocity = PVector()
+        self.center = PVector()
         self.partSize = random(10, 60)
         # The particle is a textured quad.
-        self.part = createShape()
-        self.part.beginShape(QUAD)
-        self.part.noStroke()
-        self.part.texture(sprite)
-        self.part.normal(0, 0, 1)
-        self.part.vertex(-self.partSize / 2, -self.partSize / 2, 0, 0)
-        self.part.vertex(self.partSize / 2,
-                         -self.partSize / 2, sprite.width, 0)
-        self.part.vertex(self.partSize / 2,
-                         self.partSize / 2, sprite.width, sprite.height)
-        self.part.vertex(-self.partSize / 2,
-                         self.partSize / 2, 0, sprite.height)
-        self.part.endShape()
-        # Initialize center vector.
-        self.center = PVector()
+        self.shape = self.makeShape(sprite)
         # Set the particle starting location.
         self.rebirth(width / 2, height / 2)
 
+    def makeShape(self, sprite):
+        shape = createShape()
+        shape.beginShape(QUAD)
+        shape.noStroke()
+        shape.texture(sprite)
+        shape.normal(0, 0, 1)
+        shape.vertex(-self.partSize / 2, -self.partSize / 2,
+                     0, 0)
+        shape.vertex(self.partSize / 2, -self.partSize / 2,
+                     sprite.width, 0)
+        shape.vertex(self.partSize / 2, self.partSize / 2,
+                     sprite.width, sprite.height)
+        shape.vertex(-self.partSize / 2, self.partSize / 2,
+                     0, sprite.height)
+        shape.endShape()
+        return shape
+
     def getShape(self):
-        return self.part
+        return self.shape
 
     def rebirth(self, x, y):
-        a = random(TWO_PI)
-        speed = random(0.5, 4)
-        # A velocity with random angle and magnitude.
-        self.velocity = PVector.fromAngle(a)
-        self.velocity.mult(speed)
         # Set lifespan.
         self.lifespan = 255
-        # Set location using translate.
-        self.part.resetMatrix()
-        self.part.translate(x, y)
-        # Update center vector.
+        # Set velocity.
+        self.velocity = PVector.fromAngle(random(TAU))
+        # Set speed.
+        self.velocity.mult(random(0.5, 4))
+        # Reset location using translate.
+        self.shape.resetMatrix()
+        self.shape.translate(x, y)
+        # Set center vector.
         self.center.set(x, y, 0)
 
     # Is it off the screen, or its lifespan is over?
     def isDead(self):
         return (self.center.x > width or self.center.x < 0
-                or self.center.y > height or self.center.y < 0 or
-                self.lifespan < 0)
+                or self.center.y > height or self.center.y < 0
+                or self.lifespan < 0)
 
     def update(self):
         # Decrease life.
         self.lifespan = self.lifespan - 1
         # Apply gravity.
-        self.velocity.add(self.gravity)
-        self.part.setTint(color(255, self.lifespan))
+        self.velocity.add(Particle.Gravity)
+        self.shape.setTint(color(255, self.lifespan))
         # Move the particle according to its velocity,
-        self.part.translate(self.velocity.x, self.velocity.y)
+        self.shape.translate(self.velocity.x, self.velocity.y)
         # and also update the center
         self.center.add(self.velocity)
-

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle.py
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle.py
@@ -12,29 +12,29 @@ class Particle(object):
         self.center = PVector()
         self.partSize = random(10, 60)
         # The particle is a textured quad.
-        self.shape = self.makeShape(sprite)
+        self.shp = self.makeShape(sprite)
         # Set the particle starting location.
         self.rebirth(width / 2, height / 2)
 
     def makeShape(self, sprite):
-        shape = createShape()
-        shape.beginShape(QUAD)
-        shape.noStroke()
-        shape.texture(sprite)
-        shape.normal(0, 0, 1)
-        shape.vertex(-self.partSize / 2, -self.partSize / 2,
-                     0, 0)
-        shape.vertex(self.partSize / 2, -self.partSize / 2,
-                     sprite.width, 0)
-        shape.vertex(self.partSize / 2, self.partSize / 2,
-                     sprite.width, sprite.height)
-        shape.vertex(-self.partSize / 2, self.partSize / 2,
-                     0, sprite.height)
-        shape.endShape()
-        return shape
+        shp = createShape()
+        shp.beginShape(QUAD)
+        shp.noStroke()
+        shp.texture(sprite)
+        shp.normal(0, 0, 1)
+        shp.vertex(-self.partSize / 2, -self.partSize / 2,
+                   0, 0)
+        shp.vertex(self.partSize / 2, -self.partSize / 2,
+                   sprite.width, 0)
+        shp.vertex(self.partSize / 2, self.partSize / 2,
+                   sprite.width, sprite.height)
+        shp.vertex(-self.partSize / 2, self.partSize / 2,
+                   0, sprite.height)
+        shp.endShape()
+        return shp
 
     def getShape(self):
-        return self.shape
+        return self.shp
 
     def rebirth(self, x, y):
         # Set lifespan.
@@ -44,8 +44,8 @@ class Particle(object):
         # Set speed.
         self.velocity.mult(random(0.5, 4))
         # Reset location using translate.
-        self.shape.resetMatrix()
-        self.shape.translate(x, y)
+        self.shp.resetMatrix()
+        self.shp.translate(x, y)
         # Set center vector.
         self.center.set(x, y, 0)
 
@@ -60,8 +60,8 @@ class Particle(object):
         self.lifespan = self.lifespan - 1
         # Apply gravity.
         self.velocity.add(Particle.Gravity)
-        self.shape.setTint(color(255, self.lifespan))
+        self.shp.setTint(color(255, self.lifespan))
         # Move the particle according to its velocity,
-        self.shape.translate(self.velocity.x, self.velocity.y)
+        self.shp.translate(self.velocity.x, self.velocity.y)
         # and also update the center
         self.center.add(self.velocity)

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle_system.py
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle_system.py
@@ -6,7 +6,7 @@ from particle import Particle
 class ParticleSystem(object):
 
     def __init__(self, n):
-        sprite = loadImage("data/sprite.png")
+        sprite = loadImage("sprite.png")
         # Make all the Particles.
         # It's just a list of particle objects.
         self.particles = [Particle(sprite) for _ in range(n)]

--- a/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle_system.py
+++ b/mode/examples/Topics/Create Shapes/ParticleSystemPShape/particle_system.py
@@ -6,28 +6,25 @@ from particle import Particle
 class ParticleSystem(object):
 
     def __init__(self, n):
+        sprite = loadImage("data/sprite.png")
+        # Make all the Particles.
         # It's just a list of particle objects.
-        self.particles = []
+        self.particles = [Particle(sprite) for _ in range(n)]
         # The PShape to group all the particle PShapes.
         self.particleShape = createShape(GROUP)
-        # Make all the Particles.
-        sprite = loadImage("sprite.png")
-        for i in range(n):
-            p = Particle(sprite)
-            self.particles.append(p)
-            # Each particle's PShape gets added to the System PShape.
-            self.particleShape.addChild(p.getShape())
+        # Each particle's PShape gets added to the System PShape.
+        for particle in self.particles:
+            self.particleShape.addChild(particle.getShape())
 
     def update(self):
-        for p in self.particles:
-            p.update()
+        for particle in self.particles:
+            particle.update()
 
     def setEmitter(self, x, y):
-        for p in self.particles:
+        for particle in self.particles:
             # Each particle gets reborn at the emitter location.
-            if p.isDead():
-                p.rebirth(x, y)
+            if particle.isDead():
+                particle.rebirth(x, y)
 
     def display(self):
         shape(self.particleShape)
-

--- a/mode/examples/Topics/Create Shapes/PathPShape/PathPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PathPShape/PathPShape.pyde
@@ -3,8 +3,6 @@ PathPShape
 
 A simple path using PShape
 """
-# A PShape object
-path = None
 
 
 def setup():
@@ -33,4 +31,3 @@ def draw():
     # Draw the path at the mouse location.
     translate(mouseX, mouseY)
     shape(path)
-

--- a/mode/examples/Topics/Create Shapes/PathPShape/PathPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PathPShape/PathPShape.pyde
@@ -8,6 +8,7 @@ path = None
 
 
 def setup():
+    global path
     size(640, 360, P2D)
     smooth()
     # Create the shape.

--- a/mode/examples/Topics/Create Shapes/PolygonPShape/PolygonPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShape/PolygonPShape.pyde
@@ -1,14 +1,14 @@
-
 """
-PrimitivePShape. 
+PrimitivePShape.
 
-Using a PShape to display a custom polygon. 
+Using a PShape to display a custom polygon.
 """
 # The PShape object
 star = None
 
 
 def setup():
+    global star
     size(640, 360, P2D)
     smooth()
     # First create the shape.
@@ -38,4 +38,3 @@ def draw():
     translate(mouseX, mouseY)
     # Display the shape.
     shape(star)
-

--- a/mode/examples/Topics/Create Shapes/PolygonPShape/PolygonPShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShape/PolygonPShape.pyde
@@ -1,10 +1,6 @@
 """
 PrimitivePShape.
-
-Using a PShape to display a custom polygon.
 """
-# The PShape object
-star = None
 
 
 def setup():

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/PolygonPShapeOOP.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/PolygonPShapeOOP.pyde
@@ -3,12 +3,7 @@ PolygonPShapeOOP.
 
 Wrapping a PShape inside a custom class.
 """
-
 from star import Star
-
-# A Star object
-s1 = None
-s2 = None
 
 
 def setup():

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/PolygonPShapeOOP.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/PolygonPShapeOOP.pyde
@@ -1,7 +1,7 @@
 """
-PolygonPShapeOOP. 
+PolygonPShapeOOP.
 
-Wrapping a PShape inside a custom class 
+Wrapping a PShape inside a custom class.
 """
 
 from star import Star
@@ -12,6 +12,7 @@ s2 = None
 
 
 def setup():
+    global s1, s2
     size(640, 360, P2D)
     smooth()
     # Make a Star.
@@ -25,4 +26,3 @@ def draw():
     s1.move()  # Move the first star.
     s2.display()  # Display the second star.
     s2.move()  # Move the second star.
-

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/star.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/star.py
@@ -6,24 +6,24 @@ class Star(object):
         self.y = random(100, height - 100)
         self.speed = random(0.5, 3)
         # First create the shape.
-        self.s = createShape()
-        self.s.beginShape()
+        self.shape = createShape()
+        self.shape.beginShape()
         # You can set fill and stroke.
-        self.s.fill(255, 204)
-        self.s.noStroke()
+        self.shape.fill(255, 204)
+        self.shape.noStroke()
         # Here, we are hardcoding a series of vertices.
-        self.s.vertex(0, -50)
-        self.s.vertex(14, -20)
-        self.s.vertex(47, -15)
-        self.s.vertex(23, 7)
-        self.s.vertex(29, 40)
-        self.s.vertex(0, 25)
-        self.s.vertex(-29, 40)
-        self.s.vertex(-23, 7)
-        self.s.vertex(-47, -15)
-        self.s.vertex(-14, -20)
+        self.shape.vertex(0, -50)
+        self.shape.vertex(14, -20)
+        self.shape.vertex(47, -15)
+        self.shape.vertex(23, 7)
+        self.shape.vertex(29, 40)
+        self.shape.vertex(0, 25)
+        self.shape.vertex(-29, 40)
+        self.shape.vertex(-23, 7)
+        self.shape.vertex(-47, -15)
+        self.shape.vertex(-14, -20)
         # The shape is complete.
-        self.s.endShape(CLOSE)
+        self.shape.endShape(CLOSE)
 
     def move(self):
         # Demonstrating some simple motion.
@@ -35,5 +35,4 @@ class Star(object):
         # Locating and drawing the shape.
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.s)
-
+            shape(self.shape)

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/star.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP/star.py
@@ -6,24 +6,24 @@ class Star(object):
         self.y = random(100, height - 100)
         self.speed = random(0.5, 3)
         # First create the shape.
-        self.shape = createShape()
-        self.shape.beginShape()
+        self.shp = createShape()
+        self.shp.beginShape()
         # You can set fill and stroke.
-        self.shape.fill(255, 204)
-        self.shape.noStroke()
+        self.shp.fill(255, 204)
+        self.shp.noStroke()
         # Here, we are hardcoding a series of vertices.
-        self.shape.vertex(0, -50)
-        self.shape.vertex(14, -20)
-        self.shape.vertex(47, -15)
-        self.shape.vertex(23, 7)
-        self.shape.vertex(29, 40)
-        self.shape.vertex(0, 25)
-        self.shape.vertex(-29, 40)
-        self.shape.vertex(-23, 7)
-        self.shape.vertex(-47, -15)
-        self.shape.vertex(-14, -20)
+        self.shp.vertex(0, -50)
+        self.shp.vertex(14, -20)
+        self.shp.vertex(47, -15)
+        self.shp.vertex(23, 7)
+        self.shp.vertex(29, 40)
+        self.shp.vertex(0, 25)
+        self.shp.vertex(-29, 40)
+        self.shp.vertex(-23, 7)
+        self.shp.vertex(-47, -15)
+        self.shp.vertex(-14, -20)
         # The shape is complete.
-        self.shape.endShape(CLOSE)
+        self.shp.endShape(CLOSE)
 
     def move(self):
         # Demonstrating some simple motion.
@@ -35,4 +35,4 @@ class Star(object):
         # Locating and drawing the shape.
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.shape)
+            shape(self.shp)

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/PolygonPShapeOOP2.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/PolygonPShapeOOP2.pyde
@@ -1,13 +1,10 @@
 """
 PolygonPShapeOOP.
 
-Wrapping a PShape inside a custom class
-and demonstrating how we can have a multiple objects each
-using the same PShape.
+Wrapping a PShape inside a custom class and demonstrating how we can have
+multiple objects each using the same PShape.
 """
 from polygon import Polygon
-
-polygons = None
 
 
 def setup():

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/PolygonPShapeOOP2.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/PolygonPShapeOOP2.pyde
@@ -1,16 +1,17 @@
 """
-PolygonPShapeOOP. 
+PolygonPShapeOOP.
 
-Wrapping a PShape inside a custom class 
+Wrapping a PShape inside a custom class
 and demonstrating how we can have a multiple objects each
 using the same PShape.
 """
 from polygon import Polygon
-# A list of objects
-polygons = []
+
+polygons = None
 
 
 def setup():
+    global polygons
     size(640, 360, P2D)
     smooth()
     # Make a PShape.
@@ -29,13 +30,10 @@ def setup():
     star.vertex(-47, -15)
     star.vertex(-14, -20)
     star.endShape(CLOSE)
-    # Make an ArrayList.
-    polygons = []
     # Add a bunch of objects to the ArrayList.
     # Pass in reference to the PShape.
-    # We coud make polygons with different PShapes.
-    for i in range(25):
-        polygons.append(Polygon(star))
+    # We could make polygons with different PShapes.
+    polygons = [Polygon(star) for _ in range(25)]
 
 
 def draw():
@@ -44,4 +42,3 @@ def draw():
     for poly in polygons:
         poly.display()
         poly.move()
-

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/polygon.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/polygon.py
@@ -1,10 +1,10 @@
 # A class to describe a Polygon (with a PShape).
 class Polygon(object):
 
-    def __init__(self, shape):
+    def __init__(self, shp):
         self.x = random(width)
         self.y = random(-500, -100)
-        self.shape = shape
+        self.shp = shp
         self.speed = random(2, 6)
 
     # Simple motion
@@ -17,4 +17,4 @@ class Polygon(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.shape)
+            shape(self.shp)

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/polygon.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP2/polygon.py
@@ -1,10 +1,10 @@
 # A class to describe a Polygon (with a PShape).
 class Polygon(object):
 
-    def __init__(self, s):
+    def __init__(self, shape):
         self.x = random(width)
         self.y = random(-500, -100)
-        self.s = s
+        self.shape = shape
         self.speed = random(2, 6)
 
     # Simple motion
@@ -17,5 +17,4 @@ class Polygon(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.s)
-
+            shape(self.shape)

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/PolygonPShapeOOP3.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/PolygonPShapeOOP3.pyde
@@ -9,23 +9,21 @@ using the same PShape.
 import random
 from polygon import Polygon
 
-# A list of objects
-polygons = None
-# Three possible shapes
-shapes = [None] * 3
+shapes = []
 
 
 def setup():
     global polygons
     size(640, 360, P2D)
     smooth()
-    shapes[0] = createShape(ELLIPSE, 0, 0, 100, 100)
+    # Three possible shapes
+    shapes.append(createShape(ELLIPSE, 0, 0, 100, 100))
+    shapes.append(createShape(RECT, 0, 0, 100, 100))
+    shapes.append(createShape())
     shapes[0].setFill(color(255, 127))
     shapes[0].setStroke(False)
-    shapes[1] = createShape(RECT, 0, 0, 100, 100)
     shapes[1].setFill(color(255, 127))
     shapes[1].setStroke(False)
-    shapes[2] = createShape()
     shapes[2].beginShape()
     shapes[2].fill(0, 127)
     shapes[2].noStroke()

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/PolygonPShapeOOP3.pyde
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/PolygonPShapeOOP3.pyde
@@ -10,12 +10,13 @@ import random
 from polygon import Polygon
 
 # A list of objects
-polygons = []
+polygons = None
 # Three possible shapes
 shapes = [None] * 3
 
 
 def setup():
+    global polygons
     size(640, 360, P2D)
     smooth()
     shapes[0] = createShape(ELLIPSE, 0, 0, 100, 100)
@@ -40,9 +41,7 @@ def setup():
     shapes[2].vertex(-14, -20)
     shapes[2].endShape(CLOSE)
     # Make a list.
-    polygons = []
-    for i in range(25):
-        polygons.append(Polygon(random.choice(shapes)))
+    polygons = [Polygon(random.choice(shapes)) for _ in range(25)]
 
 
 def draw():
@@ -51,4 +50,3 @@ def draw():
     for poly in polygons:
         poly.display()
         poly.move()
-

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/polygon.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/polygon.py
@@ -1,10 +1,10 @@
 # A class to describe a Polygon (with a PShape).
 class Polygon(object):
 
-    def __init__(self, shape):
+    def __init__(self, shp):
         self.x = random(width)
         self.y = random(-500, -100)
-        self.shape = shape
+        self.shp = shp
         self.speed = random(2, 6)
 
     # Simple motion
@@ -17,4 +17,4 @@ class Polygon(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.shape)
+            shape(self.shp)

--- a/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/polygon.py
+++ b/mode/examples/Topics/Create Shapes/PolygonPShapeOOP3/polygon.py
@@ -1,10 +1,10 @@
 # A class to describe a Polygon (with a PShape).
 class Polygon(object):
 
-    def __init__(self, s):
+    def __init__(self, shape):
         self.x = random(width)
         self.y = random(-500, -100)
-        self.s = s
+        self.shape = shape
         self.speed = random(2, 6)
 
     # Simple motion
@@ -17,5 +17,4 @@ class Polygon(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.s)
-
+            shape(self.shape)

--- a/mode/examples/Topics/Create Shapes/PrimitivePShape/PrimitivePShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PrimitivePShape/PrimitivePShape.pyde
@@ -3,8 +3,6 @@ PrimitivePShape.
 
 Using a PShape to display a primitive shape (in this case, ellipse).
 """
-# The PShape object
-circle = None
 
 
 def setup():

--- a/mode/examples/Topics/Create Shapes/PrimitivePShape/PrimitivePShape.pyde
+++ b/mode/examples/Topics/Create Shapes/PrimitivePShape/PrimitivePShape.pyde
@@ -1,13 +1,14 @@
 """
-PrimitivePShape. 
+PrimitivePShape.
 
-Using a PShape to display a primitive shape (in this case, ellipse). 
+Using a PShape to display a primitive shape (in this case, ellipse).
 """
 # The PShape object
 circle = None
 
 
 def setup():
+    global circle
     size(640, 360, P2D)
     smooth()
     # Creating the PShape as an ellipse.
@@ -24,4 +25,3 @@ def draw():
     translate(mouseX, mouseY)
     # Drawing the PShape
     shape(circle)
-

--- a/mode/examples/Topics/Create Shapes/WigglePShape/WigglePShape.pyde
+++ b/mode/examples/Topics/Create Shapes/WigglePShape/WigglePShape.pyde
@@ -5,9 +5,6 @@ How to move the individual vertices of a PShape.
 """
 from wiggler import Wiggler
 
-# A "Wiggler" object
-wiggler = None
-
 
 def setup():
     global wiggler

--- a/mode/examples/Topics/Create Shapes/WigglePShape/WigglePShape.pyde
+++ b/mode/examples/Topics/Create Shapes/WigglePShape/WigglePShape.pyde
@@ -1,22 +1,22 @@
 """
-WigglePShape. 
+WigglePShape.
 
 How to move the individual vertices of a PShape.
 """
 from wiggler import Wiggler
 
 # A "Wiggler" object
-w = None
+wiggler = None
 
 
 def setup():
+    global wiggler
     size(640, 360, P2D)
     smooth()
-    w = Wiggler()
+    wiggler = Wiggler()
 
 
 def draw():
     background(255)
-    w.display()
-    w.wiggle()
-
+    wiggler.display()
+    wiggler.wiggle()

--- a/mode/examples/Topics/Create Shapes/WigglePShape/wiggler.py
+++ b/mode/examples/Topics/Create Shapes/WigglePShape/wiggler.py
@@ -18,19 +18,19 @@ class Wiggler(object):
             self.original.append(vec)
         # The PShape to be "wiggled".
         # Make the PShape with those vertices.
-        self.shape = createShape()
-        self.shape.beginShape()
-        self.shape.fill(127)
-        self.shape.stroke(0)
-        self.shape.strokeWeight(2)
+        self.shp = createShape()
+        self.shp.beginShape()
+        self.shp.fill(127)
+        self.shp.stroke(0)
+        self.shp.strokeWeight(2)
         for vert in self.original:
-            self.shape.vertex(vert.x, vert.y)
-        self.shape.endShape(CLOSE)
+            self.shp.vertex(vert.x, vert.y)
+        self.shp.endShape(CLOSE)
 
     def wiggle(self):
         xoff = 0
         # Apply an offset to each vertex.
-        for i in range(self.shape.getVertexCount()):
+        for i in range(self.shp.getVertexCount()):
             # Calculate a vertex location based on noise around "original"
             # location.
             pos = self.original[i]
@@ -39,7 +39,7 @@ class Wiggler(object):
             radius.mult(4)
             radius.add(pos)
             # Set the location of each vertex to the one.
-            self.shape.setVertex(i, radius)
+            self.shp.setVertex(i, radius)
             # Increment perlin noise x value.
             xoff += 0.5
         # Increment perlin noise y value.
@@ -48,4 +48,4 @@ class Wiggler(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.shape)
+            shape(self.shp)

--- a/mode/examples/Topics/Create Shapes/WigglePShape/wiggler.py
+++ b/mode/examples/Topics/Create Shapes/WigglePShape/wiggler.py
@@ -13,33 +13,33 @@ class Wiggler(object):
         self.original = []
         for a in range(0, TWO_PI * 10, 2):
             ascaled = a * .1
-            v = PVector.fromAngle(ascaled)
-            v.mult(100)
-            self.original.append(v)
+            vec = PVector.fromAngle(ascaled)
+            vec.mult(100)
+            self.original.append(vec)
         # The PShape to be "wiggled".
         # Make the PShape with those vertices.
-        self.s = createShape()
-        self.s.beginShape()
-        self.s.fill(127)
-        self.s.stroke(0)
-        self.s.strokeWeight(2)
-        for v in self.original:
-            self.s.vertex(v.x, v.y)
-        self.s.endShape(CLOSE)
+        self.shape = createShape()
+        self.shape.beginShape()
+        self.shape.fill(127)
+        self.shape.stroke(0)
+        self.shape.strokeWeight(2)
+        for vert in self.original:
+            self.shape.vertex(vert.x, vert.y)
+        self.shape.endShape(CLOSE)
 
     def wiggle(self):
         xoff = 0
         # Apply an offset to each vertex.
-        for i in range(self.s.getVertexCount()):
+        for i in range(self.shape.getVertexCount()):
             # Calculate a vertex location based on noise around "original"
             # location.
             pos = self.original[i]
             a = TWO_PI * noise(xoff, self.yoff)
-            r = PVector.fromAngle(a)
-            r.mult(4)
-            r.add(pos)
+            radius = PVector.fromAngle(a)
+            radius.mult(4)
+            radius.add(pos)
             # Set the location of each vertex to the one.
-            self.s.setVertex(i, r.x, r.y)
+            self.shape.setVertex(i, radius)
             # Increment perlin noise x value.
             xoff += 0.5
         # Increment perlin noise y value.
@@ -48,5 +48,4 @@ class Wiggler(object):
     def display(self):
         with pushMatrix():
             translate(self.x, self.y)
-            shape(self.s)
-
+            shape(self.shape)


### PR DESCRIPTION
 - Fix `Create Shapes` examples for deprecated `autoglobal`.
 - Remove extra spaces at EOL/EOF.
 - Use meaningful identifiers instead of single characters (except in some obvious cases, e.g. `x`, `y`).
 - Use list comprehensions where possible, and where they are not more complicated than the equivalent `for` construct.
 - Refactor `ParticleSystemPShape` considerably.