### PR TITLE
Update `examples\Demos` for explicit globals

### DIFF
--- a/mode/examples/Demos/Graphics/BoxClock/BoxClock.pyde
+++ b/mode/examples/Demos/Graphics/BoxClock/BoxClock.pyde
@@ -8,7 +8,7 @@
 
 
 def setup():
-    global fillCube
+    global fillCube, edgeCube
     size(500, 500, P3D)
     smooth(4)
     camera(0, 0, 100,
@@ -18,11 +18,11 @@ def setup():
     # Creating a **filled** wireframe cube is non-obvious.
     # We need an opaque black cube inside a transparent wireframe cube.
     fillCube = createShape(BOX, 2)
+    edgeCube = makeEdgeCube()
 
     # The fill color here has to match the `background` from `draw` in order
     # for the fill cube to be invisible.
     fillCube.setFill(color(10))
-    makeEdgeCube()
 
 
 def draw():
@@ -48,7 +48,6 @@ def drawShape():
 
 
 def makeEdgeCube():
-    global edgeCube
     # Draw a 2x2x2 transparent cube with edges colored according to the
     # current time.
     Red = color(255, 137, 95)  # Seconds.
@@ -90,3 +89,4 @@ def makeEdgeCube():
     edgeCube.vertex(-1, -1, -1)
     edgeCube.vertex(-1, -1, 1)
     edgeCube.endShape()
+    return edgeCube

--- a/mode/examples/Demos/Graphics/BoxClock/BoxClock.pyde
+++ b/mode/examples/Demos/Graphics/BoxClock/BoxClock.pyde
@@ -5,21 +5,18 @@
     (C) Ben Alkov, 2014, licensed as APL 2.0 as part of processing.py
     (https://github.com/jdf/processing.py).
 '''
-# Creating a **filled** wireframe cube is non-obvious.
-# We need an opaque black cube...
-fillCube = None
-# ...and a transparent colored wireframe.
-edgeCube = PShape()
 
 
 def setup():
+    global fillCube
     size(500, 500, P3D)
     smooth(4)
     camera(0, 0, 100,
            0, 0, 0,
            0, 1, 0)
 
-    # Draw a 2x2x2 opaque box.
+    # Creating a **filled** wireframe cube is non-obvious.
+    # We need an opaque black cube inside a transparent wireframe cube.
     fillCube = createShape(BOX, 2)
 
     # The fill color here has to match the `background` from `draw` in order
@@ -51,7 +48,9 @@ def drawShape():
 
 
 def makeEdgeCube():
-    # Draw a 2x2x2 transparent box with different-colored edges.
+    global edgeCube
+    # Draw a 2x2x2 transparent cube with edges colored according to the
+    # current time.
     Red = color(255, 137, 95)  # Seconds.
     Green = color(176, 255, 121)  # Minutes.
     Blue = color(56, 76, 204)  # Hours.

--- a/mode/examples/Demos/Graphics/Particles/Particles.pyde
+++ b/mode/examples/Demos/Graphics/Particles/Particles.pyde
@@ -3,9 +3,9 @@ from particle_system import ParticleSystem
 
 
 def setup():
-    size(1024, 768, P2D)
-    sprite = loadImage("sprite.png")
     global ps
+    size(512, 384, P2D)
+    sprite = loadImage("data/sprite.png")
     ps = ParticleSystem(10000, sprite)
     # Writing to the depth buffer is disabled to avoid rendering
     # artifacts due to the fact that the particles are semi-transparent
@@ -17,9 +17,7 @@ def draw():
     background(0)
     ps.update()
     ps.display()
-
     ps.setEmitter(mouseX, mouseY)
-
     fill(255)
     textSize(16)
     text("Frame rate: " + str(int(frameRate)), 10, 20)

--- a/mode/examples/Demos/Graphics/Particles/Particles.pyde
+++ b/mode/examples/Demos/Graphics/Particles/Particles.pyde
@@ -5,7 +5,7 @@ from particle_system import ParticleSystem
 def setup():
     global ps
     size(512, 384, P2D)
-    sprite = loadImage("data/sprite.png")
+    sprite = loadImage("sprite.png")
     ps = ParticleSystem(10000, sprite)
     # Writing to the depth buffer is disabled to avoid rendering
     # artifacts due to the fact that the particles are semi-transparent

--- a/mode/examples/Demos/Graphics/Particles/particle.py
+++ b/mode/examples/Demos/Graphics/Particles/particle.py
@@ -1,8 +1,9 @@
-class Particle:
+class Particle(object):
 
     def __init__(self, sprite):
         self.gravity = PVector(0, 0.1)
         self.lifespan = 255
+        self.velocity = PVector()
         partSize = random(10, 60)
         self.part = createShape()
         self.part.beginShape(QUAD)
@@ -15,7 +16,6 @@ class Particle:
                          sprite.width, sprite.height)
         self.part.vertex(-partSize / 2, +partSize / 2, 0, sprite.height)
         self.part.endShape()
-
         self.rebirth(width / 2, height / 2)
         self.lifespan = random(255)
 

--- a/mode/examples/Demos/Graphics/Particles/particle_system.py
+++ b/mode/examples/Demos/Graphics/Particles/particle_system.py
@@ -1,24 +1,22 @@
 from particle import Particle
 
 
-class ParticleSystem:
+class ParticleSystem(object):
 
     def __init__(self, n, sprite):
-        self.particles = []
         self.particleShape = createShape(PShape.GROUP)
-        for i in range(n):
-            p = Particle(sprite)
-            self.particles.append(p)
-            self.particleShape.addChild(p.getShape())
+        self.particles = [Particle(sprite) for _ in range(n)]
+        for particle in self.particles:
+            self.particleShape.addChild(particle.getShape())
 
     def update(self):
-        for p in self.particles:
-            p.update()
+        for particle in self.particles:
+            particle.update()
 
     def setEmitter(self, x, y):
-        for p in self.particles:
-            if p.isDead():
-                p.rebirth(x, y)
+        for particle in self.particles:
+            if particle.isDead():
+                particle.rebirth(x, y)
 
     def display(self):
         shape(self.particleShape)

--- a/mode/examples/Demos/Graphics/Particles/particle_system.py
+++ b/mode/examples/Demos/Graphics/Particles/particle_system.py
@@ -6,18 +6,17 @@ class ParticleSystem(object):
     def __init__(self, n, sprite):
         self.particleShape = createShape(PShape.GROUP)
         self.particles = [Particle(sprite) for _ in range(n)]
-        for particle in self.particles:
-            self.particleShape.addChild(particle.getShape())
+        for p in self.particles:
+            self.particleShape.addChild(p.getShape())
 
     def update(self):
-        for particle in self.particles:
-            particle.update()
+        for p in self.particles:
+            p.update()
 
     def setEmitter(self, x, y):
-        for particle in self.particles:
-            if particle.isDead():
-                particle.rebirth(x, y)
+        for p in self.particles:
+            if p.isDead():
+                p.rebirth(x, y)
 
     def display(self):
         shape(self.particleShape)
-

--- a/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
+++ b/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
@@ -17,6 +17,7 @@ from gesture import Gesture
 
 nGestures = 36    # Number of gestures
 minMove = 3       # Minimum travel for a point
+gestureArray = []
 
 
 def setup():
@@ -24,7 +25,8 @@ def setup():
     size(1024, 768, P2D)
     background(0, 0, 0)
     noStroke()
-    gestureArray = [Gesture(width, height) for _ in range(nGestures)]
+    for _ in range(nGestures):
+        gestureArray.append(Gesture(width, height))
     currentGestureID = -1
     clearGestures()
 

--- a/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
+++ b/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
@@ -16,20 +16,16 @@
 from gesture import Gesture
 
 nGestures = 36    # Number of gestures
-gestureArray = []
-currentGestureID = -1
-
-minMove = 3         # Minimum travel for a point
-tmpXp = []
-tmpYp = []
+minMove = 3       # Minimum travel for a point
 
 
 def setup():
+    global gestureArray, currentGestureID
     size(1024, 768, P2D)
     background(0, 0, 0)
     noStroke()
-    for _ in range(nGestures):
-        gestureArray.append(Gesture(width, height))
+    gestureArray = [Gesture(width, height) for _ in range(nGestures)]
+    currentGestureID = -1
     clearGestures()
 
 

--- a/mode/examples/Topics/Animation/AnimatedSprite/AnimatedSprite.pyde
+++ b/mode/examples/Topics/Animation/AnimatedSprite/AnimatedSprite.pyde
@@ -1,25 +1,23 @@
 """
 Animated Sprite (Shifty + Teddy)
-by James Paterson. 
+by James Paterson.
 
 Press the mouse button to change animations.
 Demonstrates loading, displaying, and animating GIF images.
-It would be easy to write a program to display 
-animated GIFs, but would not allow as much control over 
-the display sequence and rate of display. 
+It would be easy to write a program to display
+animated GIFs, but would not allow as much control over
+the display sequence and rate of display.
 """
 
 # From the file "animation.py" import the class "Animation"
 from animation import Animation
 
-animation1 = None
-animation2 = None
 xpos = 0
-ypos = 0
 drag = 30.0
 
 
 def setup():
+    global animation1, animation2, ypos
     size(640, 360)
     background(255, 204, 0)
     frameRate(24)
@@ -29,6 +27,7 @@ def setup():
 
 
 def draw():
+    global xpos
     dx = mouseX - xpos
     xpos = xpos + dx / drag
     # Display the sprite at the position xpos, ypos

--- a/mode/examples/Topics/Animation/AnimatedSprite/animation.py
+++ b/mode/examples/Topics/Animation/AnimatedSprite/animation.py
@@ -8,7 +8,7 @@ class Animation(object):
         for i in range(self.imageCount):
             # Use nf() to number format 'i' into four digits
             filename = imagePrefix + nf(i, 4) + ".gif"
-            self.images[i] = loadImage(filename)
+            self.images[i] = loadImage("data/" + filename)
 
     def display(self, xpos, ypos):
         self.frame = (self.frame + 1) % self.imageCount
@@ -16,4 +16,3 @@ class Animation(object):
 
     def getWidth(self):
         return self.images[0].width
-

--- a/mode/examples/Topics/Animation/AnimatedSprite/animation.py
+++ b/mode/examples/Topics/Animation/AnimatedSprite/animation.py
@@ -8,7 +8,7 @@ class Animation(object):
         for i in range(self.imageCount):
             # Use nf() to number format 'i' into four digits
             filename = imagePrefix + nf(i, 4) + ".gif"
-            self.images[i] = loadImage("data/" + filename)
+            self.images[i] = loadImage(filename)
 
     def display(self, xpos, ypos):
         self.frame = (self.frame + 1) % self.imageCount

--- a/mode/examples/Topics/Animation/Sequential/Sequential.pyde
+++ b/mode/examples/Topics/Animation/Sequential/Sequential.pyde
@@ -1,47 +1,45 @@
 """
 Sequential
-by James Paterson.    
+by James Paterson.
 
-Displaying a sequence of images creates the illusion of motion. 
-Twelve images are loaded and each is displayed individually in a loop. 
+Displaying a sequence of images creates the illusion of motion.
+Twelve images are loaded and each is displayed individually in a loop.
 """
 
 numFrames = 12  # The number of frames in the animation
-currentFrame = 0
 images = [PImage] * numFrames
 
 def setup():
     size(640, 360)
     frameRate(24)
 
-    images[0] = loadImage("PT_anim0000.gif")
-    images[1] = loadImage("PT_anim0001.gif")
-    images[2] = loadImage("PT_anim0002.gif")
-    images[3] = loadImage("PT_anim0003.gif")
-    images[4] = loadImage("PT_anim0004.gif")
-    images[5] = loadImage("PT_anim0005.gif")
-    images[6] = loadImage("PT_anim0006.gif")
-    images[7] = loadImage("PT_anim0007.gif")
-    images[8] = loadImage("PT_anim0008.gif")
-    images[9] = loadImage("PT_anim0009.gif")
-    images[10] = loadImage("PT_anim0010.gif")
-    images[11] = loadImage("PT_anim0011.gif")
+    images[0] = loadImage("data/PT_anim0000.gif")
+    images[1] = loadImage("data/PT_anim0001.gif")
+    images[2] = loadImage("data/PT_anim0002.gif")
+    images[3] = loadImage("data/PT_anim0003.gif")
+    images[4] = loadImage("data/PT_anim0004.gif")
+    images[5] = loadImage("data/PT_anim0005.gif")
+    images[6] = loadImage("data/PT_anim0006.gif")
+    images[7] = loadImage("data/PT_anim0007.gif")
+    images[8] = loadImage("data/PT_anim0008.gif")
+    images[9] = loadImage("data/PT_anim0009.gif")
+    images[10] = loadImage("data/PT_anim0010.gif")
+    images[11] = loadImage("data/PT_anim0011.gif")
 
     # If you don't want to load each image separately
     # and you know how many frames you have, you
     # can create the filenames as the program runs.
     # The nf() command does number formatting, which will
     # ensure that the number is (in this case) 4 digits.
-    # for i in range(numFrames):
-    #    imageName = "PT_anim" + nf(i, 4) + ".gif"
-    #    images[i] = loadImage(imageName)
+    # Using a list comprehension:
+    # images = [loadImage('data/PT_anim' + nf(i, 4) + '.gif')
+    #           for i in range(numFrames)]
     #
-
 
 def draw():
     background(0)
     # Use % to cycle through frames
-    currentFrame = (currentFrame + 1) % numFrames
+    currentFrame = (frameCount + 1) % numFrames
     offset = 0
     for x in range(-100, width, images[0].width):
         image(images[(currentFrame + offset) % numFrames], x, -20)

--- a/mode/examples/Topics/Animation/Sequential/Sequential.pyde
+++ b/mode/examples/Topics/Animation/Sequential/Sequential.pyde
@@ -13,18 +13,18 @@ def setup():
     size(640, 360)
     frameRate(24)
 
-    images[0] = loadImage("data/PT_anim0000.gif")
-    images[1] = loadImage("data/PT_anim0001.gif")
-    images[2] = loadImage("data/PT_anim0002.gif")
-    images[3] = loadImage("data/PT_anim0003.gif")
-    images[4] = loadImage("data/PT_anim0004.gif")
-    images[5] = loadImage("data/PT_anim0005.gif")
-    images[6] = loadImage("data/PT_anim0006.gif")
-    images[7] = loadImage("data/PT_anim0007.gif")
-    images[8] = loadImage("data/PT_anim0008.gif")
-    images[9] = loadImage("data/PT_anim0009.gif")
-    images[10] = loadImage("data/PT_anim0010.gif")
-    images[11] = loadImage("data/PT_anim0011.gif")
+    images[0] = loadImage("PT_anim0000.gif")
+    images[1] = loadImage("PT_anim0001.gif")
+    images[2] = loadImage("PT_anim0002.gif")
+    images[3] = loadImage("PT_anim0003.gif")
+    images[4] = loadImage("PT_anim0004.gif")
+    images[5] = loadImage("PT_anim0005.gif")
+    images[6] = loadImage("PT_anim0006.gif")
+    images[7] = loadImage("PT_anim0007.gif")
+    images[8] = loadImage("PT_anim0008.gif")
+    images[9] = loadImage("PT_anim0009.gif")
+    images[10] = loadImage("PT_anim0010.gif")
+    images[11] = loadImage("PT_anim0011.gif")
 
     # If you don't want to load each image separately
     # and you know how many frames you have, you
@@ -32,7 +32,7 @@ def setup():
     # The nf() command does number formatting, which will
     # ensure that the number is (in this case) 4 digits.
     # Using a list comprehension:
-    # images = [loadImage('data/PT_anim' + nf(i, 4) + '.gif')
+    # images = [loadImage('PT_anim' + nf(i, 4) + '.gif')
     #           for i in range(numFrames)]
     #
 


### PR DESCRIPTION
Plus a few other touch-ups here and there.
 - BoxClock: explicit globals
 - Particles: explicit globals; reduce size of sketch by half (this one in particular is *very* CPU-intensive). `particle_system`: explicit `data` folder for standalone; inherit from `object`; list comprehensions; rename for clarity. `particle`: inherit from `object`; explicitly declare `velocity` inside `__init__`.
 - Yellowtail: explicit globals; list comprehension.