### PR TITLE
- Fix broken `rm-rf` and `find` on Windows

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -49,10 +49,32 @@
   <macrodef name="rm-rf">
     <attribute name="target"/>
     <sequential>
-      <exec executable="/bin/rm" failonerror="true">
-        <arg value="-rf"/>
-        <arg value="${basedir}/@{target}"/>
-      </exec>
+      <if>
+        <or>
+          <equals arg1="${platform}" arg2="macosx"/>
+          <equals arg1="${platform}" arg2="linux32"/>
+          <equals arg1="${platform}" arg2="linux64"/>
+        </or>
+        <then>
+          <exec executable="/bin/rm" failonerror="true">
+            <arg value="-rf"/>
+            <arg value="${basedir}/@{target}"/>
+          </exec>
+        </then>
+      <!-- This `elseif` ONLY works when we have e.g. Msysgit installed on Windows -->
+      <elseif>
+          <or>
+            <equals arg1="${platform}" arg2="windows32"/>
+            <equals arg1="${platform}" arg2="windows64"/>
+          </or>
+        <then>
+          <exec executable="rm" failonerror="true">
+              <arg value="-rf"/>
+              <arg value="${basedir}/@{target}"/>
+          </exec>
+        </then>
+      </elseif>
+      </if>
     </sequential>
   </macrodef>
 
@@ -224,9 +246,14 @@
     <delete>
       <fileset dir="buildtime/py" includes="*.class"/>
     </delete>
-    <exec executable="find" failonerror="true">
-      <arg line=". -name .DS_Store -depth -exec rm {} ;"/>
-    </exec>
+    <if>
+      <equals arg1="${platform}" arg2="macosx"/>
+      <then>
+        <exec executable="find" failonerror="true">
+          <arg line=". -name .DS_Store -depth -exec rm {} ;"/>
+        </exec>
+      </then>
+    </if>
   </target>
 
   <target name="clean" depends="clean-self">


### PR DESCRIPTION
`mode.zip`, `mode.jar`, `jar`, `clean`, all work.

Unfortunately (and I have no idea why), on windows 64, ant fails on

`ant -Dplatform=windows64 make-distribution`, yielding

````
  [symlink] ln: creating symbolic link `C:\\path\\to\\processing.py/dist/processing.py-0411-windows64/libraries/processing' to `C:\\path\\to\\processing.py/.cache/libs/windows64': Permission denied
````

and, **on windows64** (I haven't tested any other platforms, but I don't anticipate issues), 

 `ant make-all-distributions` fails while executing

`target getjre for platform macosx`, yielding

````
C:\path\to\processing.py\build.xml:59: Execute failed: java.io.IOException: Cannot run program "\bin\rm": CreateProcess error=2, The system cannot find the file specified
````

but I don't know how important building dists on Windows is.