### PR TITLE
Fixed shader examples

### DIFF
--- a/mode/examples/Topics/Shaders/BlurFilter/BlurFilter.pyde
+++ b/mode/examples/Topics/Shaders/BlurFilter/BlurFilter.pyde
@@ -9,6 +9,7 @@ blur = None
 
 
 def setup():
+    global blur
     size(640, 360, P2D)
     blur = loadShader("blur.glsl")
     stroke(255, 0, 0)
@@ -19,4 +20,3 @@ def draw():
     filter(blur)
     rect(mouseX, mouseY, 150, 150)
     ellipse(mouseX, mouseY, 100, 100)
-

--- a/mode/examples/Topics/Shaders/Conway/Conway.pyde
+++ b/mode/examples/Topics/Shaders/Conway/Conway.pyde
@@ -7,6 +7,7 @@ conway = None
 pg = None
 
 def setup():
+    global conway, pg
     size(400, 400, P3D)
     conway = loadShader("conway.glsl")
     pg = createGraphics(400, 400, P2D)
@@ -25,4 +26,3 @@ def draw():
     pg.rect(0, 0, pg.width, pg.height)
     pg.endDraw()
     image(pg, 0, 0, width, height)
-

--- a/mode/examples/Topics/Shaders/CustomBlend/CustomBlend.pyde
+++ b/mode/examples/Topics/Shaders/CustomBlend/CustomBlend.pyde
@@ -29,6 +29,7 @@ difference = None
 
 
 def setup():
+    global destImage, srcImage
     size(640, 360, P2D)
     destImage = loadImage("leaves.jpg")
     srcImage = loadImage("moonwalk.jpg")
@@ -49,6 +50,7 @@ def draw():
 
 
 def initShaders():
+    global dodge, burn, overlay, difference
     dodge = loadShader("dodge.glsl")
     burn = loadShader("burn.glsl")
     overlay = loadShader("overlay.glsl")
@@ -99,4 +101,3 @@ def drawOutput(x, y, w, h):
             vertex(w, 0, 1, 0)
             vertex(w, h, 1, 1)
             vertex(0, h, 0, 1)
-

--- a/mode/examples/Topics/Shaders/Deform/Deform.pyde
+++ b/mode/examples/Topics/Shaders/Deform/Deform.pyde
@@ -13,6 +13,7 @@ deform = None
 
 
 def setup():
+    global tex, deform
     size(640, 360, P2D)
     textureWrap(REPEAT)
     tex = loadImage("tex1.jpg")
@@ -25,4 +26,3 @@ def draw():
     deform.set("mouse", float(mouseX), float(mouseY))
     shader(deform)
     image(tex, 0, 0, width, height)
-

--- a/mode/examples/Topics/Shaders/EdgeDetect/EdgeDetect.pyde
+++ b/mode/examples/Topics/Shaders/EdgeDetect/EdgeDetect.pyde
@@ -11,6 +11,7 @@ enabled = True
 
 
 def setup():
+    global img, edges, enabled
     size(640, 360, P2D)
     img = loadImage("leaves.jpg")
     edges = loadShader("edges.glsl")
@@ -23,7 +24,7 @@ def draw():
 
 
 def mousePressed():
+    global enabled
     enabled = not enabled
     if not enabled:
         resetShader()
-

--- a/mode/examples/Topics/Shaders/EdgeFilter/EdgeFilter.pyde
+++ b/mode/examples/Topics/Shaders/EdgeFilter/EdgeFilter.pyde
@@ -11,6 +11,7 @@ applyFilter = True
 
 
 def setup():
+    global edges
     size(640, 360, P3D)
     edges = loadShader("edges.glsl")
     noStroke()
@@ -34,5 +35,5 @@ def draw():
 
 
 def mousePressed():
+    global applyFilter
     applyFilter = not applyFilter
-

--- a/mode/examples/Topics/Shaders/GlossyFishEye/GlossyFishEye.pyde
+++ b/mode/examples/Topics/Shaders/GlossyFishEye/GlossyFishEye.pyde
@@ -14,6 +14,7 @@ useFishEye = True
 
 
 def setup():
+    global fisheye, glossy, canvas, img, ball
     size(640, 640, P3D)
     canvas = createGraphics(width, height, P3D)
     fisheye = loadShader("FishEye.glsl")
@@ -54,6 +55,7 @@ def draw():
 
 
 def mousePressed():
+    global useFishEye
     useFishEye = not useFishEye
     if not useFishEye:
         resetShader()

--- a/mode/examples/Topics/Shaders/ImageMask/ImageMask.pyde
+++ b/mode/examples/Topics/Shaders/ImageMask/ImageMask.pyde
@@ -10,6 +10,7 @@ maskImage = None
 
 
 def setup():
+    global maskShader, srcImage, maskImage
     size(640, 360, P2D)
     srcImage = loadImage("leaves.jpg")
     maskImage = createGraphics(srcImage.width, srcImage.height, P2D)
@@ -29,4 +30,3 @@ def draw():
     maskImage.endDraw()
     shader(maskShader)
     image(srcImage, 0, 0, width, height)
-

--- a/mode/examples/Topics/Shaders/Landscape/Landscape.pyde
+++ b/mode/examples/Topics/Shaders/Landscape/Landscape.pyde
@@ -10,6 +10,7 @@ elevatedshader = None
 
 
 def setup():
+    global elevatedshader
     size(640, 360, P2D)
     noStroke()
     # The code of this shader shows how to integrate shaders from shadertoy

--- a/mode/examples/Topics/Shaders/Monjori/Monjori.pyde
+++ b/mode/examples/Topics/Shaders/Monjori/Monjori.pyde
@@ -12,6 +12,7 @@ monjori = None
 
 
 def setup():
+    global monjori
     size(640, 360, P2D)
     noStroke()
     monjori = loadShader("monjori.glsl")
@@ -26,4 +27,3 @@ def draw():
     # entire view area so every pixel is pushed through the
     # shader.
     rect(0, 0, width, height)
-

--- a/mode/examples/Topics/Shaders/Nebula/Nebula.pyde
+++ b/mode/examples/Topics/Shaders/Nebula/Nebula.pyde
@@ -10,6 +10,7 @@ nebula = None
 
 
 def setup():
+    global nebula
     size(640, 360, P2D)
     noStroke()
     nebula = loadShader("nebula.glsl")
@@ -23,4 +24,3 @@ def draw():
     # fragment shader, they only need a quad covering the entire view
     # area so every pixel is pushed through the shader.
     rect(0, 0, width, height)
-

--- a/mode/examples/Topics/Shaders/SepBlur/SepBlur.pyde
+++ b/mode/examples/Topics/Shaders/SepBlur/SepBlur.pyde
@@ -13,6 +13,7 @@ pass2 = None
 
 
 def setup():
+    global blur, src, pass1, pass2
     size(640, 360, P2D)
 
     blur = loadShader("blur.glsl")
@@ -53,6 +54,7 @@ def draw():
 
 
 def keyPressed():
+    global blur
     if key == '9':
         blur.set("blurSize", 9)
         blur.set("sigma", 5.0)
@@ -65,4 +67,3 @@ def keyPressed():
     elif key == '3':
         blur.set("blurSize", 3)
         blur.set("sigma", 1.0)
-

--- a/mode/examples/Topics/Shaders/ToonShading/ToonShading.pyde
+++ b/mode/examples/Topics/Shaders/ToonShading/ToonShading.pyde
@@ -12,6 +12,7 @@ shaderEnabled = True
 
 
 def setup():
+    global toon
     size(640, 360, P3D)
     noStroke()
     fill(204)
@@ -31,6 +32,7 @@ def draw():
 
 
 def mousePressed():
+    global shaderEnabled
     shaderEnabled = not shaderEnabled
     if not shaderEnabled:
         resetShader()


### PR DESCRIPTION
The shader examples failed to run due to them using variables declared outside the scope of `setup()`. Shader examples have been tweaked to use the global namespace wherever a variable needed to be written to in the global scope.