### PR TITLE
Rewrote the missing Example->Basic->Math->Map example in Python Mode

### DIFF
--- a/mode/examples/Basics/Math/Map/Map.pyde
+++ b/mode/examples/Basics/Math/Map/Map.pyde
@@ -1,0 +1,26 @@
+'''
+/**
+ * Map.
+ * 
+ * Use the map() function to take any number and scale it to a new number 
+ * that is more useful for the project that you are working on. For example, use the
+ * numbers from the mouse position to control the size or color of a shape. 
+ * In this example, the mouse’s x-coordinate (numbers between 0 and 360) are scaled to
+ * new numbers to define the color and size of a circle.
+ */
+ Example ReWritten in Python By: Prabhjot Singh (NITH)
+ example original in Java mode examples: Math->Maps
+ '''
+def setup():
+    size(640, 360)
+    noStroke()
+
+def draw():
+    background(0)
+  # Scale the mouseX value from 0 to 640 to a range between 0 and 175
+    c = map(mouseX, 0, width, 0, 175)
+  # Scale the mouseX value from 0 to 640 to a range between 40 and 300
+    d = map(mouseX, 0, width, 40, 300)
+    fill(255, c, 0)
+    ellipse(width/2, height/2, d, d)
+    

--- a/mode/examples/Basics/Math/Map/Map.pyde
+++ b/mode/examples/Basics/Math/Map/Map.pyde
@@ -1,25 +1,27 @@
 '''
  Map.
-  
+ 
  Use the map() function to take any number and scale it to a new number 
- that is more useful for the project that you are working on. 
- For example, use the numbers from the mouse position to control the size or color of a shape. 
+ that is more useful for the project that you are working on. For example, use the
+ numbers from the mouse position to control the size or color of a shape. 
  In this example, the mouse’s x-coordinate (numbers between 0 and 360) are scaled to
  new numbers to define the color and size of a circle.
  
  Example ReWritten in Python By: Prabhjot Singh (NITH)
  example original in Java mode examples: Math->Maps
- '''
+'''
 def setup():
     size(640, 360)
     noStroke()
 
 def draw():
     background(0)
-  # Scale the mouseX value from 0 to 640 to a range between 0 and 175
+
+    # Scale the mouseX value from 0 to 640 to a range between 0 and 175
     c = map(mouseX, 0, width, 0, 175)
-  # Scale the mouseX value from 0 to 640 to a range between 40 and 300
+
+    # Scale the mouseX value from 0 to 640 to a range between 40 and 300
     d = map(mouseX, 0, width, 40, 300)
+
     fill(255, c, 0)
-    ellipse(width/2, height/2, d, d)
-    
+    ellipse(width / 2, height / 2, d, d)

--- a/mode/examples/Basics/Math/Map/Map.pyde
+++ b/mode/examples/Basics/Math/Map/Map.pyde
@@ -1,13 +1,12 @@
 '''
-/**
- * Map.
- * 
- * Use the map() function to take any number and scale it to a new number 
- * that is more useful for the project that you are working on. For example, use the
- * numbers from the mouse position to control the size or color of a shape. 
- * In this example, the mouse’s x-coordinate (numbers between 0 and 360) are scaled to
- * new numbers to define the color and size of a circle.
- */
+ Map.
+  
+ Use the map() function to take any number and scale it to a new number 
+ that is more useful for the project that you are working on. 
+ For example, use the numbers from the mouse position to control the size or color of a shape. 
+ In this example, the mouse’s x-coordinate (numbers between 0 and 360) are scaled to
+ new numbers to define the color and size of a circle.
+ 
  Example ReWritten in Python By: Prabhjot Singh (NITH)
  example original in Java mode examples: Math->Maps
  '''


### PR DESCRIPTION
synchronizing the missing data for Python Mode.
Please add this example too.