### PR TITLE
Fixed Issue #172: Extra classname under file menu Python Mode

### DIFF
--- a/runtime/src/jycessing/mode/PyEditor.java
+++ b/runtime/src/jycessing/mode/PyEditor.java
@@ -157,7 +157,7 @@ public class PyEditor extends Editor {
    */
   @Override
   public JMenu buildFileMenu() {
-    final String appTitle = Language.text("toolbar.export_application");
+    final String appTitle = Language.text("Export Application");
     final JMenuItem exportApplication = Toolkit.newJMenuItem(appTitle, 'E');
     exportApplication.addActionListener(new ActionListener() {
       @Override


### PR DESCRIPTION
Now there is proper "Export Application" under the File menu.

 Extra classname under file menu Python Mode #172 
