### PR TITLE
fix for createInput and createOutput plus tests

### DIFF
--- a/runtime/src/jycessing/core.py
+++ b/runtime/src/jycessing/core.py
@@ -528,6 +528,18 @@ __builtin__.year = PApplet.year
 # Here are some names that resolve to static *and* instance methods.
 # Dispatch them to the appropriate methods based on the type of their
 # arguments.
+def __createInput__(o):
+    if isinstance(o, basestring):
+        return __papplet__.createInput(o)
+    return PApplet.createInput(o)
+__builtin__.createInput = __createInput__
+
+def __createOutput__(o):
+    if isinstance(o, basestring):
+        return __papplet__.createOutput(o)
+    return PApplet.createOutput(o)
+__builtin__.createOutput = __createOutput__
+
 def __createReader__(o):
     if isinstance(o, basestring):
         return __papplet__.createReader(o)

--- a/testing/resources/test_loadthings.py
+++ b/testing/resources/test_loadthings.py
@@ -28,5 +28,14 @@ a = loadJSONArray(File("testing/resources/data/array.json"))
 assert a.getString(0) == 'hello'
 assert a.getString(1) == 'world'
 
+expected = ['hello', 'world']
+helloworld = loadStrings(createInput("strings.txt"))
+assert helloworld[0] == 'hello'
+assert helloworld[1] == 'world'
+
+helloworld = loadStrings(createInput(File("testing/resources/data/strings.txt")))
+assert helloworld[0] == 'hello'
+assert helloworld[1] == 'world'
+
 print 'OK'
 exit()

--- a/testing/resources/test_writethings.py
+++ b/testing/resources/test_writethings.py
@@ -1,0 +1,25 @@
+import tempfile
+from java.io import File
+
+content = "hello"
+
+# guaranteed to be deleted on close and/or garbage collection
+with tempfile.NamedTemporaryFile() as tmpfile:
+
+    writer = createOutput(tmpfile.name)
+    saveBytes(writer, content)
+    tmpfile.flush()
+    reader = createInput(tmpfile.name)
+    data = loadBytes(reader)
+    assert ''.join([chr(c) for c in data]) == content
+
+    writer = createOutput(File(tmpfile.name))
+    saveBytes(writer, content)
+    tmpfile.flush()
+    reader = createInput(tmpfile.name)
+    data = loadBytes(reader)
+    assert ''.join([chr(c) for c in data]) == content
+
+print 'OK'
+exit()
+

--- a/testing/src/test/jycessing/JycessingTests.java
+++ b/testing/src/test/jycessing/JycessingTests.java
@@ -22,6 +22,7 @@ import jycessing.StreamPrinter;
 import org.junit.Test;
 
 public class JycessingTests {
+
   private static class CapturingPrinter implements Printer {
     private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     private final PrintStream out = new PrintStream(baos, true);
@@ -208,6 +209,11 @@ public class JycessingTests {
   @Test
   public void loadThings() throws Exception {
     expectOK("loadthings");
+  }
+
+  @Test
+  public void writeThings() throws Exception {
+    expectOK("writethings");
   }
 
   @Test


### PR DESCRIPTION
This pull request fixes an issue in which the following code...

```
fh = createInput("test.txt")
```

... raises `TypeError: createInput(): 1st arg can't be coerced to String, java.io.File`. The fix consists of adding the same static/instance fix for `createInput()` in `core.py` that is already there for similar PApplet methods (along with a unit test of same). For good measure, a fix and test for `createOutput()` are also included.