### PR TITLE
Fixes type error in range()

### DIFF
--- a/examples.py/Basics/Color/WaveGradient.py
+++ b/examples.py/Basics/Color/WaveGradient.py
@@ -5,6 +5,7 @@
    
   Generate a gradient along a sin() wave.
 """
+import math
 
 amplitude = 30
 fillGap = 2.5
@@ -28,7 +29,7 @@ def draw():
                 255 - abs(py - i) * 255 / amplitude,
                 j * (255.0 / (width + 50)))
       # Hack to fill gaps. Raise value of fillGap if you increase frequency
-      for filler in range(fillGap):
+      for filler in range(int(math.ceil(fillGap))):
         set(int(j - filler), int(py) - filler, c)
         set(int(j), int(py), c)
         set(int(j + filler), int(py) + filler, c)


### PR DESCRIPTION
@jdf  The for loop in line 31 uses range and it gives type error since `fillGap` is a float. The complete error is as follows : 

`processing.app.SketchException: TypeError: range() integer end argument expected, got float.`

This PR fixes it.