### PR TITLE
Improve description for finding tutorials

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ def draw():
     fill(frameCount % 255, 255, 255)
     ellipse(mouseX, mouseY, 20, 20)
 ```
-If you are just getting started, it is a good idea to go through the [tutorials](http://py.processing.org/tutorials/).
+If you are just getting started, it is a good idea to go through the [tutorials on our website](http://py.processing.org/tutorials/), and alternatively some [examples](mode/examples).
 
 
 ## Using Processing Libraries ##

--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,7 @@ def draw():
     fill(frameCount % 255, 255, 255)
     ellipse(mouseX, mouseY, 20, 20)
 ```
+If you are just getting started, it is a good idea to go through the [tutorials](http://py.processing.org/tutorials/).
 
 
 ## Using Processing Libraries ##


### PR DESCRIPTION
Update README to add the tutorial links, since I couldn't find any in the readme !
Partial reference to #195 for better documentation. 
Ping: @jdf 