### PR TITLE
fix undeclared global error

### DIFF
--- a/mode/examples/Contributed Libraries in Python/OpenCV/LiveCamTest/LiveCamTest.pyde
+++ b/mode/examples/Contributed Libraries in Python/OpenCV/LiveCamTest/LiveCamTest.pyde
@@ -34,4 +34,5 @@ def captureEvent(c):
     c.read()
 
 def mousePressed():
+    global show_fps
     show_fps = not show_fps


### PR DESCRIPTION
without this clicking a mouse would give show_fps referenced before assignment error.