### PR TITLE
To avoid crash on "coded" keys

### DIFF
--- a/mode/examples/Basics/Input/KeyboardFunctions/KeyboardFunctions.pyde
+++ b/mode/examples/Basics/Input/KeyboardFunctions/KeyboardFunctions.pyde
@@ -55,10 +55,12 @@ def draw():
 
 def keyPressed():
     global newletter, x, y, letterHeight
-
+    if key != CODED:
+        key_code = ord(key)
+    else:
+        key_code = keyCode
     # If the key is between 'A'(65) to 'Z' and 'a' to 'z'(122)
-    key_code = ord(key)
-    if (key_code >= A_code and key_code <= Z_code) or (key_code >= a_code and key_code <= z_code):
+    if A_code <= key_code <= Z_code or a_code <= key_code <= z_code:
         if key_code <= Z_code:
             keyIndex = key_code - A_code
             letterHeight = maxHeight


### PR DESCRIPTION
On Python Mode, when coded keys are pressed (like UP, DOWN, SHIFT) `key` returns an int constant that can't be used on ord(). Also `keyCode` does not indicate char case (so it can't be used to replace `key_code` on this example). This can be tested using:
```
print(str(key), keyCode) 

```