### PR TITLE
Add processing 3.5.3 new methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ misc/windowsexecutablestub/Debug
 misc/windowsexecutablestub/Release
 *.sdf
 *.suo
+linux/

--- a/HOWTO-HACK.txt
+++ b/HOWTO-HACK.txt
@@ -41,11 +41,14 @@ the original repo:
 
     $ git clone https://github.com/jdf/processing.py.git
 
-  
+
 You'll need source for processing and processing-video.
 
     $ git clone --depth=1 https://github.com/processing/processing.git
     $ git clone --depth=1 https://github.com/processing/processing-video.git
+
+If you are a Linux user, you'll also have to create a directory named `linux`
+inside your `processing.py` directory.
 
 Then, to sanity-check your environment and run all of Python Mode's
 integration tests, do the following:

--- a/runtime/src/jycessing/core.py
+++ b/runtime/src/jycessing/core.py
@@ -543,6 +543,7 @@ makePopper('beginShape', 'endShape')
 makePopper('beginShape', 'endShape',
            close_args=[CLOSE], exposed_name='beginClosedShape')
 makePopper('beginCamera', 'endCamera')
+makePopper('push', 'pop')
 
 import os
 os.chdir(__cwd__)

--- a/runtime/src/jycessing/core.py
+++ b/runtime/src/jycessing/core.py
@@ -274,7 +274,8 @@ for f in """
     strokeJoin strokeWeight textAlign textAscent textDescent textFont textLeading
     textMode textSize textWidth textureMode textureWrap thread tint translate
     triangle updatePixels vertex
-    image background mask blend copy cursor texture    
+    image background mask blend copy cursor texture
+    circle square push pop
 """.split():
     assert getattr(__papplet__, f)
     setattr(__builtin__, f, getattr(__papplet__, f))

--- a/testing/resources/test_pixels.py
+++ b/testing/resources/test_pixels.py
@@ -42,5 +42,20 @@ for x in range(70, 80):
         set(x, y, '#EEEE00')
 assert get(75, 15) == 0xFFEEEE00
 
+background(100)
+fill('#0000FF')
+rect(0, 0, 10, 10)
+assert get(5, 5) == 0xFF0000FF
+
+with push():
+    translate(20, 0)
+    fill(255)
+    rect(0, 0, 10, 10)
+
+assert get(25, 5) == 0xFFFFFFFF
+
+rect(40, 0, 10, 10)
+assert get(45, 5) == 0xFF0000FF  # pop also restores previous style confs
+
 print 'OK'
 exit()

--- a/testing/resources/test_pixels.py
+++ b/testing/resources/test_pixels.py
@@ -8,6 +8,9 @@ assert get(15, 15) == 0xFF0000FF
 square(10, 30, 10)
 assert get(15, 35) == 0xFF0000FF
 
+circle(100, 100, 10)
+assert get(99, 99) == 0xFF0000FF
+
 fill(255)
 rect(20, 10, 10, 10)
 assert get(25, 15) == 0xFFFFFFFF

--- a/testing/resources/test_pixels.py
+++ b/testing/resources/test_pixels.py
@@ -5,6 +5,9 @@ fill('#0000FF')
 rect(10, 10, 10, 10)
 assert get(15, 15) == 0xFF0000FF
 
+square(10, 30, 10)
+assert get(15, 35) == 0xFF0000FF
+
 fill(255)
 rect(20, 10, 10, 10)
 assert get(25, 15) == 0xFFFFFFFF


### PR DESCRIPTION
Fixes #336 

This PR add the new methods added by Processing 3.5.3 and also enable the use of `push` and `pop` as context managers.

I struggled with the build process, but I wasn't successful. I'm always running into this error:

```
BUILD FAILED
/home/bernardo/workspace/processing.py/build.xml:216: The following error occurred while executing this line:
/home/bernardo/workspace/processing/build/build.xml:57: Unsupported Java version: 10.0.2. To build, make sure that Java 8 (aka Java 1.8) is installed.
```

Even though I have Java 8 installed and my `JAVA_HOME` env var set to use my Java 8 installation. I'm not that familiar with Java and a lot of posts I read on Stackoverflow suggests me to use an IDE to build instead of the command line.