### PR TITLE
Run exported sketches using size() in present. Fix #356

### DIFF
--- a/runtime/src/jycessing/mode/export/ExportedSketch.java
+++ b/runtime/src/jycessing/mode/export/ExportedSketch.java
@@ -106,7 +106,7 @@ public class ExportedSketch implements RunnableSketch {
     final List<String> args = new ArrayList<>();
 
     if (displayType == DisplayType.PRESENTATION) {
-      args.add("fullScreen");
+      args.add("--present");
       args.add("BGCOLOR" + "=" + backgroundColor);
 
       if (stopColor != null) {


### PR DESCRIPTION
The argument "fullScreen" should be "--present" to present the exported application properly.