### PR TITLE
Added logging for PythonInterpreter.initialize, fixed bgcolor and stop button color in present mode

### DIFF
--- a/runtime/src/jycessing/Runner.java
+++ b/runtime/src/jycessing/Runner.java
@@ -321,6 +321,7 @@ public class Runner {
     props.setProperty("python.main.root", sketchDirPath);
 
     final String[] args = sketch.getPAppletArguments();
+	log("PythonInterpreter.initialize args: " + String.join(" ", args));
     PythonInterpreter.initialize(null, props, args);
 
     final PySystemState sys = Py.getSystemState();

--- a/runtime/src/jycessing/Runner.java
+++ b/runtime/src/jycessing/Runner.java
@@ -321,7 +321,7 @@ public class Runner {
     props.setProperty("python.main.root", sketchDirPath);
 
     final String[] args = sketch.getPAppletArguments();
-	log("PythonInterpreter.initialize args: " + String.join(" ", args));
+    log("PythonInterpreter.initialize args: " + String.join(" ", args));
     PythonInterpreter.initialize(null, props, args);
 
     final PySystemState sys = Py.getSystemState();

--- a/runtime/src/jycessing/mode/PyEditor.java
+++ b/runtime/src/jycessing/mode/PyEditor.java
@@ -34,6 +34,7 @@ import processing.app.Library;
 import processing.app.Messages;
 import processing.app.Mode;
 import processing.app.Platform;
+import processing.app.Preferences;
 import processing.app.SketchCode;
 import processing.app.SketchException;
 import processing.app.syntax.JEditTextArea;
@@ -341,7 +342,8 @@ public class PyEditor extends Editor {
 
     try {
       sketchService.runSketch(
-          new PdeSketch(sketch, sketchPath, displayType, location, locationType));
+				new PdeSketch(sketch, sketchPath, displayType, location, locationType,
+						Preferences.get("run.present.bgcolor"), Preferences.get("run.present.stop.color")));
     } catch (final SketchException e) {
       statusError(e);
     }

--- a/runtime/src/jycessing/mode/PyEditor.java
+++ b/runtime/src/jycessing/mode/PyEditor.java
@@ -342,8 +342,8 @@ public class PyEditor extends Editor {
 
     try {
       sketchService.runSketch(
-				new PdeSketch(sketch, sketchPath, displayType, location, locationType,
-						Preferences.get("run.present.bgcolor"), Preferences.get("run.present.stop.color")));
+          new PdeSketch(sketch, sketchPath, displayType, location, locationType,
+              Preferences.get("run.present.bgcolor"), Preferences.get("run.present.stop.color")));
     } catch (final SketchException e) {
       statusError(e);
     }

--- a/runtime/src/jycessing/mode/export/ExportedSketch.java
+++ b/runtime/src/jycessing/mode/export/ExportedSketch.java
@@ -55,7 +55,7 @@ public class ExportedSketch implements RunnableSketch {
     }
     this.code = code.toString();
 
-    if (Arrays.asList(args).contains("fullScreen")) {
+    if (Arrays.asList(args).contains(PApplet.ARGS_PRESENT)) {
       this.displayType = DisplayType.PRESENTATION;
     } else {
       this.displayType = DisplayType.WINDOWED;
@@ -64,7 +64,7 @@ public class ExportedSketch implements RunnableSketch {
     String backgroundColor = null;
     String stopColor = null;
     for (final String arg : args) {
-      if (arg.contains("BGCOLOR")) {
+      if (arg.contains(PApplet.ARGS_WINDOW_COLOR)) {
         backgroundColor = arg.substring(arg.indexOf("=") + 1);
       } else if (arg.contains(PApplet.ARGS_STOP_COLOR)) {
         stopColor = arg.substring(arg.indexOf("=") + 1);
@@ -106,8 +106,8 @@ public class ExportedSketch implements RunnableSketch {
     final List<String> args = new ArrayList<>();
 
     if (displayType == DisplayType.PRESENTATION) {
-      args.add("--present");
-      args.add("BGCOLOR" + "=" + backgroundColor);
+      args.add(PApplet.ARGS_PRESENT);
+      args.add(PApplet.ARGS_WINDOW_COLOR + "=" + backgroundColor);
 
       if (stopColor != null) {
         args.add(PApplet.ARGS_STOP_COLOR + "=" + stopColor);

--- a/runtime/src/jycessing/mode/export/LinuxExport.java
+++ b/runtime/src/jycessing/mode/export/LinuxExport.java
@@ -143,9 +143,9 @@ public class LinuxExport extends PlatformExport {
     options.add("--exported");
 
     if (presentMode) {
-      options.add("fullScreen");
+      options.add(PApplet.ARGS_PRESENT);
 
-      options.add("BGCOLOR" + "=" + Preferences.get("run.present.bgcolor"));
+      options.add(PApplet.ARGS_WINDOW_COLOR + "=" + Preferences.get("run.present.bgcolor"));
     }
 
     if (stopButton) {

--- a/runtime/src/jycessing/mode/export/MacExport.java
+++ b/runtime/src/jycessing/mode/export/MacExport.java
@@ -241,9 +241,9 @@ public class MacExport extends PlatformExport {
     options.add("--exported");
 
     if (presentMode) {
-      options.add("fullScreen");
+      options.add(PApplet.ARGS_PRESENT);
 
-      options.add("BGCOLOR" + "=" + Preferences.get("run.present.bgcolor"));
+      options.add(PApplet.ARGS_WINDOW_COLOR + "=" + Preferences.get("run.present.bgcolor"));
     }
 
     if (stopButton) {

--- a/runtime/src/jycessing/mode/export/WindowsExport.java
+++ b/runtime/src/jycessing/mode/export/WindowsExport.java
@@ -237,8 +237,8 @@ public class WindowsExport extends PlatformExport {
     // Options to pass to Runner
     final List<String> runnerOptions = new ArrayList<>();
     if (presentMode) {
-      runnerOptions.add("fullScreen");
-      runnerOptions.add("BGCOLOR" + "=" + Preferences.get("run.present.bgcolor"));
+      runnerOptions.add(PApplet.ARGS_PRESENT);
+      runnerOptions.add(PApplet.ARGS_WINDOW_COLOR + "=" + Preferences.get("run.present.bgcolor"));
     }
     if (stopButton) {
       runnerOptions.add(PApplet.ARGS_STOP_COLOR + "=" + Preferences.get("run.present.stop.color"));

--- a/runtime/src/jycessing/mode/run/PdeSketch.java
+++ b/runtime/src/jycessing/mode/run/PdeSketch.java
@@ -33,6 +33,8 @@ public class PdeSketch implements RunnableSketch, Serializable {
   private final Point location;
   private final LocationType locationType;
   private final DisplayType displayType;
+	private final String bgColor;
+	private final String stopColor;
 
   public final String[] codeFileNames; // unique to PdeSketch - leave as public field?
 
@@ -41,11 +43,13 @@ public class PdeSketch implements RunnableSketch, Serializable {
       final File sketchPath,
       final DisplayType displayType,
       final Point location,
-      final LocationType locationType) {
+			final LocationType locationType, final String bgColor, final String stopColor) {
 
     this.displayType = displayType;
     this.location = location;
     this.locationType = locationType;
+    this.bgColor = bgColor;
+    this.stopColor = stopColor;
 
     this.mainFile = sketchPath.getAbsoluteFile();
     this.mainCode = sketch.getMainProgram();
@@ -103,7 +107,9 @@ public class PdeSketch implements RunnableSketch, Serializable {
         }
         break;
       case PRESENTATION:
-        args.add("--present");
+			args.add(PApplet.ARGS_PRESENT);
+			args.add(String.join("=", PApplet.ARGS_WINDOW_COLOR, bgColor));
+			args.add(String.join("=", PApplet.ARGS_STOP_COLOR, stopColor));
         break;
     }
 

--- a/runtime/src/jycessing/mode/run/PdeSketch.java
+++ b/runtime/src/jycessing/mode/run/PdeSketch.java
@@ -107,9 +107,9 @@ public class PdeSketch implements RunnableSketch, Serializable {
         }
         break;
       case PRESENTATION:
-			args.add(PApplet.ARGS_PRESENT);
-			args.add(String.join("=", PApplet.ARGS_WINDOW_COLOR, bgColor));
-			args.add(String.join("=", PApplet.ARGS_STOP_COLOR, stopColor));
+        args.add(PApplet.ARGS_PRESENT);
+        args.add(String.join("=", PApplet.ARGS_WINDOW_COLOR, bgColor));
+        args.add(String.join("=", PApplet.ARGS_STOP_COLOR, stopColor));
         break;
     }
 


### PR DESCRIPTION
I noticed the background color wasn't working in present mode on my last fix. While investigating I saw the same problem replicated in the other export classes. I switched everything to use the PApplet constants for compatibility and maintenance. I also added bgcolor and stopbutton color args to the PdeSketch to handle background color and stop button color.