### PR TITLE
Couple of fixes

### DIFF
--- a/runtime/src/jycessing/PAppletJythonDriver.java
+++ b/runtime/src/jycessing/PAppletJythonDriver.java
@@ -883,9 +883,9 @@ public class PAppletJythonDriver extends PApplet {
   }
 
   public void runAndBlock(final String[] args) throws PythonSketchError {
+    PApplet.runSketch(args, this);
     bringToFront();
 
-    PApplet.runSketch(args, this);
     try {
       finishedLatch.await();
     } catch (final InterruptedException interrupted) {

--- a/runtime/src/jycessing/jni/OSX.java
+++ b/runtime/src/jycessing/jni/OSX.java
@@ -1,13 +1,14 @@
 package jycessing.jni;
 
+import jycessing.mode.PythonMode;
 import processing.core.PApplet;
 import processing.core.PConstants;
 
 public class OSX {
   private static volatile boolean didLoad = false;
 
-  static {
-    if (PApplet.platform == PConstants.MACOSX) {
+  public static void bringToFront() {
+    if (!didLoad && (PApplet.platform == PConstants.MACOSX)) {
       try {
         System.loadLibrary("jniosx");
         didLoad = true;
@@ -15,12 +16,23 @@ public class OSX {
         System.err.println("Hmm. Can't load native code to bring window to front.");
       }
     }
-  }
-
-  public static void bringToFront() {
     if (didLoad) {
       activateIgnoringOtherApps();
     }
+  }
+
+  public static void bringToFront(PythonMode mode) {
+    if (!didLoad && (PApplet.platform == PConstants.MACOSX)) {
+      String path = null;
+      try {
+        path = mode.getContentFile("mode").getAbsolutePath() + "/libjniosx.dylib";
+        System.load(path);
+        didLoad = true;
+      } catch (final UnsatisfiedLinkError err) {
+        System.err.println("Hmm. Can't load native code to bring window to front using the absolute path: " + path + ".");
+      }
+    }
+    bringToFront();
   }
 
   private static native void activateIgnoringOtherApps();

--- a/runtime/src/jycessing/mode/PyEditor.java
+++ b/runtime/src/jycessing/mode/PyEditor.java
@@ -21,6 +21,7 @@ import javax.swing.JOptionPane;
 
 import jycessing.DisplayType;
 import jycessing.IOUtil;
+import jycessing.jni.OSX;
 import jycessing.mode.export.ExportDialog;
 import jycessing.mode.run.PdeSketch;
 import jycessing.mode.run.PdeSketch.LocationType;
@@ -45,6 +46,8 @@ import processing.app.ui.EditorException;
 import processing.app.ui.EditorState;
 import processing.app.ui.EditorToolbar;
 import processing.app.ui.Toolkit;
+import processing.core.PApplet;
+import processing.core.PConstants;
 
 @SuppressWarnings("serial")
 public class PyEditor extends Editor {
@@ -349,10 +352,17 @@ public class PyEditor extends Editor {
     }
   }
 
+  private void bringToFront() {
+    if (PApplet.platform == PConstants.MACOSX) {
+      OSX.bringToFront(pyMode);
+    }
+  }
+
   @Override
   public void deactivateRun() {
     restoreToolbar();
     cleanupTempSketch();
+    bringToFront();
   }
 
   public void handleRun() {


### PR DESCRIPTION
I found the fix for #346 and in the process found a way to bring the IDE back to the front - showing the doc and menu as would be expected. I removed the static initialization in OSX.java and loaded the libraries in the methods themselves, which didn't seem to cause any problems. If there's a reason that needs to happen in the static initializer, let me know and I'll switch it back.