### PR TITLE
Removed processing.app.Platform static methods. Fix #371

### DIFF
--- a/runtime/src/jycessing/LibraryImporter.java
+++ b/runtime/src/jycessing/LibraryImporter.java
@@ -29,7 +29,6 @@ import org.python.core.PySystemState;
 import org.python.google.common.base.Joiner;
 import org.python.util.InteractiveConsole;
 
-import processing.app.Platform;
 import processing.core.PApplet;
 
 /**
@@ -139,9 +138,10 @@ class LibraryImporter {
     log("mainJar: " + mainJar);
     log("Adding dir: " + contentsDir);
     recursivelyAddJarsToClasspath(contentsDir);
-    if (Platform.isWindows()) {
+    log("Platform: " + PLATFORM + " Bits: " + BITS);
+    if (PLATFORM.indexOf("windows") != -1) {
       File nativeDir;
-      nativeDir = new File(libDir, "library/windows" + Platform.getVariant());
+      nativeDir = new File(libDir, "library/windows" + BITS);
       if (!nativeDir.isDirectory()) {
         nativeDir = contentsDir;
       }


### PR DESCRIPTION
addLibrary was relying on static methods from processing.app.Platform.
Those methods are part of the PDE and weren't available to exported
sketches. Replaced with local variables.