### PR TITLE
Remove remnants of js formatting

### DIFF
--- a/mode/examples/Basics/Camera/MoveEye/MoveEye.pyde
+++ b/mode/examples/Basics/Camera/MoveEye/MoveEye.pyde
@@ -1,9 +1,9 @@
 """
- * Move Eye. 
- * by Simon Greenwold.
- * 
- * The camera lifts up (controlled by mouseY) while looking at the same point.
- """
+Move Eye.
+by Simon Greenwold.
+
+The camera lifts up (controlled by mouseY) while looking at the same point.
+"""
 
 
 def setup():
@@ -26,4 +26,3 @@ def draw():
     line(-100, 0, 0, 100, 0, 0)
     line(0, -100, 0, 0, 100, 0)
     line(0, 0, -100, 0, 0, 100)
-

--- a/mode/examples/Basics/Image/Alphamask/Alphamask.pyde
+++ b/mode/examples/Basics/Image/Alphamask/Alphamask.pyde
@@ -1,10 +1,10 @@
 """
- * Alpha Mask. 
- * 
- * Loads a "mask" for an image to specify the transparency 
- * in different parts of the image. The two images are blended
- * together using the mask() method of PImage. 
- """
+Alpha Mask.
+
+Loads a "mask" for an image to specify the transparency
+in different parts of the image. The two images are blended
+together using the mask() method of PImage.
+"""
 
 
 def setup():
@@ -20,4 +20,3 @@ def draw():
     background(0, 102, 153)
     image(img, width / 2, height / 2)
     image(img, mouseX, mouseY)
-

--- a/mode/examples/Basics/Image/BackgroundImage/BackgroundImage.pyde
+++ b/mode/examples/Basics/Image/BackgroundImage/BackgroundImage.pyde
@@ -1,10 +1,10 @@
 """
- * Background Image. 
- * 
- * This example presents the fastest way to load a background image
- * into Processing. To load an image as the background, it must be
- * the same width and height as the program.
- """
+Background Image.
+
+This example presents the fastest way to load a background image
+into Processing. To load an image as the background, it must be
+the same width and height as the program.
+"""
 
 y = 0
 
@@ -26,4 +26,3 @@ def draw():
     y += 1
     if y > height:
         y = 0
-

--- a/mode/examples/Basics/Image/CreateImage/CreateImage.pyde
+++ b/mode/examples/Basics/Image/CreateImage/CreateImage.pyde
@@ -1,9 +1,9 @@
 """
- * Create Image. 
- * 
- * The createImage() function provides a fresh buffer of pixels to play with.
- * This example creates an image gradient.
- """
+Create Image.
+
+The createImage() function provides a fresh buffer of pixels to play with.
+This example creates an image gradient.
+"""
 
 
 def setup():
@@ -20,4 +20,3 @@ def draw():
     background(0)
     image(img, 90, 80)
     image(img, mouseX - img.width / 2, mouseY - img.height / 2)
-

--- a/mode/examples/Basics/Image/LoadDisplayImage/LoadDisplayImage.pyde
+++ b/mode/examples/Basics/Image/LoadDisplayImage/LoadDisplayImage.pyde
@@ -1,9 +1,9 @@
 """
- * Load and Display 
- * 
- * Images can be loaded and displayed to the screen at their actual size
- * or any other size. 
- """
+Load and Display
+
+Images can be loaded and displayed to the screen at their actual size
+or any other size.
+"""
 
 
 def setup():
@@ -20,4 +20,3 @@ def draw():
     image(img, 0, 0)
     # Displays the image at point (0, height/2) at half of its size
     image(img, 0, height / 2, img.width / 2, img.height / 2)
-

--- a/mode/examples/Basics/Image/Pointillism/Pointillism.pyde
+++ b/mode/examples/Basics/Image/Pointillism/Pointillism.pyde
@@ -1,11 +1,11 @@
 """
- * Pointillism
- * by Daniel Shiffman. 
- * 
- * Mouse horizontal location controls size of dots. 
- * Creates a simple pointillist effect using ellipses colored
- * according to pixels in an image. 
- """
+Pointillism
+by Daniel Shiffman.
+
+Mouse horizontal location controls size of dots.
+Creates a simple pointillist effect using ellipses colored
+according to pixels in an image.
+"""
 
 smallPoint = 4
 largePoint = 40
@@ -26,4 +26,3 @@ def draw():
     pix = img.get(x, y)
     fill(pix, 128)
     ellipse(x, y, pointillize, pointillize)
-

--- a/mode/examples/Basics/Image/RequestImage/RequestImage.pyde
+++ b/mode/examples/Basics/Image/RequestImage/RequestImage.pyde
@@ -1,15 +1,16 @@
 """
- * Request Image
- * by Ira Greenberg ( From Processing for Flash Developers). 
- * 
- * Shows how to use the requestImage() function with preloader animation. 
- * The requestImage() function loads images on a separate thread so that 
- * the sketch does not freeze while they load. It's very useful when you are
- * loading large images. 
- * 
- * These images are small for a quick download, but try it with your own huge 
- * images to get the full effect. 
- """
+Request Image
+by Ira Greenberg ( From Processing for Flash Developers).
+
+Shows how to use the requestImage() function with preloader animation.
+The requestImage() function loads images on a separate thread so that
+the sketch does not freeze while they load. It's very useful when you are
+loading large images.
+
+These images are small for a quick download, but try it with your own huge
+images to get the full effect.
+"""
+
 imgCount = 12
 
 imgs = []
@@ -57,7 +58,7 @@ theta = 0
 
 def runLoaderAni():
     global loaderX, loaderY, theta
-    
+
     # Only run when images are loading
     if not all(loadStates):
         ellipse(loaderX, loaderY, 10, 10)
@@ -67,4 +68,3 @@ def runLoaderAni():
         # Reposition ellipse if it goes off the screen
         if loaderX > width + 5:
             loaderX = -5
-

--- a/mode/examples/Basics/Image/Transparency/Transparency.pyde
+++ b/mode/examples/Basics/Image/Transparency/Transparency.pyde
@@ -1,10 +1,10 @@
 """
- * Transparency. 
- * 
- * Move the pointer left and right across the image to change
- * its position. This program overlays one image over another 
- * by modifying the alpha value of the image with the tint() function. 
- """
+Transparency.
+
+Move the pointer left and right across the image to change
+its position. This program overlays one image over another
+by modifying the alpha value of the image with the tint() function.
+"""
 
 offset = 0
 easing = 0.05
@@ -23,4 +23,3 @@ def draw():
     offset += dx * easing
     tint(255, 127)    # Display at half opacity
     image(img, offset, 0)
-

--- a/mode/examples/Basics/Lists/List/List.pyde
+++ b/mode/examples/Basics/Lists/List/List.pyde
@@ -1,14 +1,14 @@
 """
- * List. 
- * 
- * A list is an ordered collection of data. Each piece of data in
- * a list is identified by an index number representing its position in 
- * the list. Lists are zero based, which means that the first 
- * element in the list is [0], the second element is [1], and so on. 
- * In this example, an array named "coswav" is created and
- * filled with the cosine values. This data is displayed three 
- * separate ways on the screen.    
- """
+List.
+
+A list is an ordered collection of data. Each piece of data in
+a list is identified by an index number representing its position in
+the list. Lists are zero based, which means that the first
+element in the list is [0], the second element is [1], and so on.
+In this example, an array named "coswav" is created and
+filled with the cosine values. This data is displayed three
+separate ways on the screen.
+"""
 
 # You can create a new, empty list with a pair of square brackets:
 coswave = []
@@ -40,4 +40,3 @@ def draw():
     for i in range(0, width, 2):
         stroke(255 - coswave[i] * 255)
         line(i, y1, i, y2)
-

--- a/mode/examples/Basics/Lists/List2D/List2D.pyde
+++ b/mode/examples/Basics/Lists/List2D/List2D.pyde
@@ -1,12 +1,12 @@
 """
- * List 2D. 
- * 
- * Demonstrates the syntax for creating a two-dimensional (2D) list,
- * which, in Python, is simply a list of lists.
- * Values in a 2D list are accessed through two index values.    
- * 2D arrays are useful for storing images. In this example, each dot 
- * is colored in relation to its distance from the center of the image. 
- """
+List 2D.
+
+Demonstrates the syntax for creating a two-dimensional (2D) list,
+which, in Python, is simply a list of lists.
+Values in a 2D list are accessed through two index values.
+2D arrays are useful for storing images. In this example, each dot
+is colored in relation to its distance from the center of the image.
+"""
 
 # By convention, Python constants have UPPERCASE_NAMES.
 SPACER = 10
@@ -38,4 +38,3 @@ def draw():
         for y in range(0, height, SPACER):
             stroke(distances[x][y])
             point(x + SPACER / 2, y + SPACER / 2)
-

--- a/mode/examples/Basics/Lists/ListObjects/ListObjects.pyde
+++ b/mode/examples/Basics/Lists/ListObjects/ListObjects.pyde
@@ -1,8 +1,8 @@
 """
- * List Objects.
- *
- * Demonstrates the syntax for creating a list of custom objects.
- """
+List Objects.
+
+Demonstrates the syntax for creating a list of custom objects.
+"""
 
 from module import MovingBall
 
@@ -24,4 +24,3 @@ def draw():
     for b in balls:
         b.update()
         b.draw()
-

--- a/mode/examples/Basics/Structure/CreateGraphics/CreateGraphics.pyde
+++ b/mode/examples/Basics/Structure/CreateGraphics/CreateGraphics.pyde
@@ -1,11 +1,11 @@
 """
- * Create Graphics. 
- * 
- * The createGraphics() function creates an object from the PGraphics class 
- * PGraphics is the main graphics and rendering context for Processing. 
- * The beginDraw() method is necessary to prepare for drawing and endDraw() is
- * necessary to finish. Use this class if you need to draw into an off-screen 
- * graphics buffer or to maintain two contexts with different properties.
+Create Graphics.
+
+The createGraphics() function creates an object from the PGraphics class
+PGraphics is the main graphics and rendering context for Processing.
+The beginDraw() method is necessary to prepare for drawing and endDraw() is
+necessary to finish. Use this class if you need to draw into an off-screen
+graphics buffer or to maintain two contexts with different properties.
 """
 
 
@@ -31,4 +31,3 @@ def draw():
 
     # Draw the offscreen buffer to the screen with image()
     image(pg, 120, 60)
-

--- a/mode/examples/Basics/Structure/Functions/Functions.pyde
+++ b/mode/examples/Basics/Structure/Functions/Functions.pyde
@@ -1,9 +1,9 @@
 """
- * Functions. 
- * 
- * The drawTarget() function makes it easy to draw many distinct targets. 
- * Each call to drawTarget() specifies the position, size, and number of 
- * rings for each target. 
+Functions.
+
+The drawTarget() function makes it easy to draw many distinct targets.
+Each call to drawTarget() specifies the position, size, and number of
+rings for each target. 
 """
 
 
@@ -26,4 +26,3 @@ def drawTarget(xloc, yloc, size, num):
     for i in range(num):
         fill(i * grayvalues)
         ellipse(xloc, yloc, size - i * steps, size - i * steps)
-

--- a/mode/examples/Basics/Structure/NoLoop/NoLoop.pyde
+++ b/mode/examples/Basics/Structure/NoLoop/NoLoop.pyde
@@ -1,16 +1,16 @@
 """
- * No Loop. 
- * 
- * The noLoop() function causes draw() to only
- * execute once. Without calling noLoop(), the 
- * code inside draw() is run continually. 
- """
+No Loop.
+
+The noLoop() function causes draw() to only
+execute once. Without calling noLoop(), the
+code inside draw() is run continually. 
+"""
 
 y = 180
 
 def setup():
-    """ 
-    The statements in the setup() function 
+    """
+    The statements in the setup() function
     execute once when the program begins
     """
     size(640, 360)    # Size should be the first statement
@@ -31,4 +31,3 @@ def draw():
     if (y < 0):
         y = height
     line(0, y, width, y)
-

--- a/mode/examples/Basics/Structure/SetupDraw/SetupDraw.pyde
+++ b/mode/examples/Basics/Structure/SetupDraw/SetupDraw.pyde
@@ -1,9 +1,9 @@
 """
- * Setup and Draw.
- *
- * The code inside the draw() function runs continuously
- * from top to bottom until the program is stopped.
- """
+Setup and Draw.
+
+The code inside the draw() function runs continuously
+from top to bottom until the program is stopped.
+"""
 y = 100
 
 
@@ -31,4 +31,3 @@ def draw():
         y = height
 
     line(0, y, width, y)
-

--- a/mode/examples/Basics/Typography/Letters/Letters.pyde
+++ b/mode/examples/Basics/Typography/Letters/Letters.pyde
@@ -1,9 +1,9 @@
 """
- * Letters. 
- * 
- * Draws letters to the screen. This requires loading a font, 
- * setting the font, and then drawing the letters.
- """
+Letters.
+
+Draws letters to the screen. This requires loading a font,
+setting the font, and then drawing the letters.
+"""
 
 
 def setup():
@@ -35,4 +35,3 @@ def draw():
             text(letter, x, y)
             # Increment the counter
             counter += 1
-

--- a/mode/examples/Basics/Typography/Words/Words.pyde
+++ b/mode/examples/Basics/Typography/Words/Words.pyde
@@ -1,10 +1,10 @@
 """
- * Words. 
- * 
- * The text() function is used for writing words to the screen.
- * The letters can be aligned left, center, or right with the 
- * textAlign() function. 
- """
+Words.
+
+The text() function is used for writing words to the screen.
+The letters can be aligned left, center, or right with the
+textAlign() function.
+"""
 
 
 def setup():
@@ -37,4 +37,3 @@ def drawType(x):
     text("san", x, 165)
     fill(255)
     text("shi", x, 210)
-

--- a/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
+++ b/mode/examples/Demos/Graphics/Yellowtail/Yellowtail.pyde
@@ -1,17 +1,17 @@
 """
- * Yellowtail
- * by Golan Levin (www.flong.com).
- * Translated to Python by Jonathan Feinberg.
- *
- * Click, drag, and release to create a kinetic gesture.
- *
- * Yellowtail (1998-2000) is an interactive software system for the gestural
- * creation and performance of real-time abstract animation. Yellowtail repeats
- * a user's strokes end-over-end, enabling simultaneous specification of a
- * line's shape and quality of movement. Each line repeats according to its
- * own period, producing an ever-changing and responsive display of lively,
- * worm-like textures.
- """
+Yellowtail
+by Golan Levin (www.flong.com).
+Translated to Python by Jonathan Feinberg.
+
+Click, drag, and release to create a kinetic gesture.
+
+Yellowtail (1998-2000) is an interactive software system for the gestural
+creation and performance of real-time abstract animation. Yellowtail repeats
+a user's strokes end-over-end, enabling simultaneous specification of a
+line's shape and quality of movement. Each line repeats according to its
+own period, producing an ever-changing and responsive display of lively,
+worm-like textures.
+"""
 
 from gesture import Gesture
 
@@ -137,4 +137,3 @@ def advanceGesture(gesture):
 def clearGestures():
     for g in gestureArray:
         g.clear()
-


### PR DESCRIPTION
Some of the example sketches have left-over asterisk characters (after converting to Python). I removed these to make everything consistent. 