### PR TITLE
adding reflection to wrap use of the frame object

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,11 +3,12 @@
 	<classpathentry kind="src" path="runtime/src"/>
 	<classpathentry kind="src" path="testing/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/processing-app"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/processing-core"/>
 	<classpathentry kind="lib" path="buildtime/lib/jython/jython.jar" sourcepath="buildtime/lib/jython/jython-src.jar"/>
 	<classpathentry kind="lib" path="buildtime/lib/java/guava-17.0.jar" sourcepath="buildtime/lib/java/guava-17.0-sources.jar"/>
 	<classpathentry kind="lib" path="/processing-core/library/jogl-all.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/processing4-app"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/processing4-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/processing4-javafx"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/runtime/src/jycessing/PAppletJythonDriver.java
+++ b/runtime/src/jycessing/PAppletJythonDriver.java
@@ -1334,7 +1334,12 @@ public class PAppletJythonDriver extends PApplet {
     super.size(iwidth, iheight, irenderer, ipath);
     if (frameField != null) {
       // should surface be added instead? [fry 210616]
-      builtins.__setitem__("frame", Py.java2py(frame));
+      try {
+        Frame frameObj = (Frame) frameField.get(this);
+        builtins.__setitem__("frame", Py.java2py(frameObj));
+      } catch (IllegalAccessException ignored) {
+        // log this?
+      }
     }
     builtins.__setitem__("width", pyint(width));
     builtins.__setitem__("height", pyint(height));
@@ -1375,7 +1380,12 @@ public class PAppletJythonDriver extends PApplet {
   public void setup() {
     if (frameField != null) {
       // should surface be added instead? [fry 210616]
-      builtins.__setitem__("frame", Py.java2py(frame));
+      try {
+        Frame frameObj = (Frame) frameField.get(this);
+        builtins.__setitem__("frame", Py.java2py(frameObj));
+      } catch (IllegalAccessException ignored) {
+        // log this?
+      }
     }
     wrapProcessingVariables();
     if (mode == Mode.STATIC) {

--- a/runtime/src/jycessing/PAppletJythonDriver.java
+++ b/runtime/src/jycessing/PAppletJythonDriver.java
@@ -14,6 +14,7 @@
 package jycessing;
 
 import java.awt.Component;
+import java.awt.Frame;
 import java.awt.Point;
 import java.awt.Window;
 import java.awt.event.ComponentAdapter;
@@ -102,6 +103,8 @@ public class PAppletJythonDriver extends PApplet {
     // select box to fire twice, skipping confirmation the first time.
     useNativeSelect = false;
   }
+
+  private Field frameField;
 
   private PythonSketchError terminalException = null;
 
@@ -454,10 +457,30 @@ public class PAppletJythonDriver extends PApplet {
     builtins.__setitem__("keyCode", pyint(0));
   }
 
+  // method to find the frame field, rather than relying on an Exception
+  private Field getFrameField() {
+    for (Field field : getClass().getFields()) {
+      if (field.getName().equals("frame")) {
+        return field;
+      }
+    }
+    return null;
+  }
+
   @Override
   protected PSurface initSurface() {
     final PSurface s = super.initSurface();
-    this.frame = null; // eliminate a memory leak from 2.x compat hack
+
+    frameField = getFrameField();
+    if (frameField != null) {
+      try {
+        // eliminate a memory leak from 2.x compat hack
+        frameField.set(this, null);
+      } catch (Exception e) {
+        // safe enough to ignore; this was a workaround
+      }
+    }
+
     s.setTitle(pySketchPath.getFileName().toString().replaceAll("\\..*$", ""));
     if (s instanceof PSurfaceAWT) {
       final PSurfaceAWT surf = (PSurfaceAWT) s;
@@ -916,7 +939,15 @@ public class PAppletJythonDriver extends PApplet {
         // exits or we explicitly tell it to minimize.
         // (If it's disposed, it'll leave a gray blank window behind it.)
         Runner.log("Disabling fullscreen.");
-        macosxFullScreenToggle(frame);
+
+        if (frameField != null) {
+          try {
+            Frame frameObj = (Frame) frameField.get(this);
+            macosxFullScreenToggle(frameObj);
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+        }
       }
       if (surface instanceof PSurfaceFX) {
         // Sadly, JavaFX is an abomination, and there's no way to run an FX sketch more than once,
@@ -1301,7 +1332,10 @@ public class PAppletJythonDriver extends PApplet {
   public void size(
       final int iwidth, final int iheight, final String irenderer, final String ipath) {
     super.size(iwidth, iheight, irenderer, ipath);
-    builtins.__setitem__("frame", Py.java2py(frame));
+    if (frameField != null) {
+      // should surface be added instead? [fry 210616]
+      builtins.__setitem__("frame", Py.java2py(frame));
+    }
     builtins.__setitem__("width", pyint(width));
     builtins.__setitem__("height", pyint(height));
   }
@@ -1339,7 +1373,10 @@ public class PAppletJythonDriver extends PApplet {
 
   @Override
   public void setup() {
-    builtins.__setitem__("frame", Py.java2py(frame));
+    if (frameField != null) {
+      // should surface be added instead? [fry 210616]
+      builtins.__setitem__("frame", Py.java2py(frame));
+    }
     wrapProcessingVariables();
     if (mode == Mode.STATIC) {
       // A static sketch gets called once, from this spot.


### PR DESCRIPTION
Possible fix for #382, with caveats:

* There might be other references to `frame`, this is just fixing the obvious one one on startup, and others in that file.
* Not sure if `surface` should be made available (noted in two locations)
* I'm not sure what the MacOS full screen thing is doing: is it still necessary? (Perhaps it's a leftover from using “native” fullscreen on older OS X releases?)
* Just a quick fix, not fully vetted.
