### PR TITLE
Updates for changes to processing4

### DIFF
--- a/runtime/src/jycessing/PAppletJythonDriver.java
+++ b/runtime/src/jycessing/PAppletJythonDriver.java
@@ -78,7 +78,6 @@ import processing.core.PImage;
 import processing.core.PSurface;
 import processing.event.KeyEvent;
 import processing.event.MouseEvent;
-import processing.javafx.PSurfaceFX;
 import processing.opengl.PGraphicsOpenGL;
 import processing.opengl.PShader;
 import processing.opengl.PSurfaceJOGL;
@@ -502,8 +501,6 @@ public class PAppletJythonDriver extends PApplet {
               finishedLatch.countDown();
             }
           });
-    } else if (s instanceof PSurfaceFX) {
-      System.err.println("I don't know how to watch FX2D windows for close.");
     }
 
     final PyObject pyG;
@@ -948,12 +945,6 @@ public class PAppletJythonDriver extends PApplet {
             e.printStackTrace();
           }
         }
-      }
-      if (surface instanceof PSurfaceFX) {
-        // Sadly, JavaFX is an abomination, and there's no way to run an FX sketch more than once,
-        // so we must actually exit.
-        Runner.log("JavaFX requires SketchRunner to terminate. Farewell!");
-        System.exit(0);
       }
       final Object nativeWindow = surface.getNative();
       if (nativeWindow instanceof com.jogamp.newt.Window) {

--- a/testmode.sh
+++ b/testmode.sh
@@ -6,8 +6,8 @@ PROCESSING=../processing4
 
 MODES=~/Documents/Processing/modes;
 if [[ $(uname) == 'Darwin' ]]; then
-	RUNPROCESSING=$PROCESSING/build/macosx/work/Processing.app/Contents/MacOS/Processing
-else 
+	RUNPROCESSING=$PROCESSING/build/macos/work/Processing.app/Contents/MacOS/Processing
+else
 	RUNPROCESSING="$PROCESSING/build/linux/work/processing"
 	MODES=~/sketchbook/modes;
 fi


### PR DESCRIPTION
build/macos was renamed to build/macosx in d6fe5cac339bce5dfa8bb589779aabba5c7c496d.

javafx was moved in a605ff53ba08480856e64938d78d3c6a15d6b018 and then removed
entirely in bade983019dff85f59cdaadc1be25410ea7afc93; see also
https://github.com/processing/processing4/issues/348.